### PR TITLE
fix: harden orchestration bootstrap runtime

### DIFF
--- a/src/minime/db/repository.py
+++ b/src/minime/db/repository.py
@@ -1093,7 +1093,7 @@ class PostgresJobRepository(JobRepositoryInterface):
             raise ValueError(f"Job '{job_id}' not found.")
         current = JobStatus(model.status)
         target = JobStatus(new_status)
-        if target not in self._valid_transitions[current]:
+        if target not in self.VALID_TRANSITIONS[current]:
             raise ValueError(f"Invalid job status transition: {current.value} -> {target.value}.")
         model.status = target.value
         model.error_message = error_message
@@ -1112,7 +1112,7 @@ class PostgresJobRepository(JobRepositoryInterface):
             raise ValueError(f"Job '{job_id}' not found.")
         current = JobStatus(model.status)
         target = JobStatus.WAITING_CAPACITY
-        if target not in self._valid_transitions[current]:
+        if target not in self.VALID_TRANSITIONS[current]:
             raise ValueError(f"Invalid job status transition: {current.value} -> {target.value}.")
         model.status = target.value
         model.waiting_provider = waiting_provider
@@ -1127,7 +1127,7 @@ class PostgresJobRepository(JobRepositoryInterface):
             raise ValueError(f"Job '{job_id}' not found.")
         current = JobStatus(model.status)
         target = JobStatus.RECOVERY_BLOCKED
-        if target not in self._valid_transitions[current]:
+        if target not in self.VALID_TRANSITIONS[current]:
             raise ValueError(f"Invalid job status transition: {current.value} -> {target.value}.")
         model.status = target.value
         model.recovery_blocked_reason = reason

--- a/src/minime/services/orchestration_service.py
+++ b/src/minime/services/orchestration_service.py
@@ -400,8 +400,22 @@ class OrchestrationService:
                 try:
                     job = asyncio.run(self.pipeline.execute_queued_job(job.job_id))
                 except Exception as exc:
-                    logger.error(f"Error executing job attempt for run '{run.run_id}': {exc}")
-                    job = self.uow.jobs.get_by_id(run.active_job_id)
+                    redacted_error = redact_secrets(str(exc))
+                    logger.exception(
+                        "Error executing job attempt for run '%s': %s", run.run_id, redacted_error
+                    )
+                    self._stop_run(
+                        run,
+                        stop_outcome=OrchestrationStopOutcome.NEEDS_HUMAN,
+                        human_gate=HumanGate.NEEDS_HUMAN,
+                        stop_reason="Execution pipeline failed unexpectedly.",
+                        stop_details={
+                            "code": "EXECUTION_PIPELINE_EXCEPTION",
+                            "exception_type": type(exc).__name__,
+                            "error": redacted_error,
+                        },
+                    )
+                    break
 
                 if not job:
                     self._stop_run(

--- a/tests/test_orchestration_coordinator.py
+++ b/tests/test_orchestration_coordinator.py
@@ -474,6 +474,63 @@ def test_end_to_end_successful_orchestration(setup_orchestration_environment, in
     assert status_view.audit_status == "AUDIT_COMPLETED"
 
 
+def test_pipeline_exception_stops_before_evaluation_and_all_downstream_stages(
+    setup_orchestration_environment, in_memory_uow
+):
+    env = setup_orchestration_environment
+    pipeline = ExecutionPipelineService(
+        uow=in_memory_uow,
+        project_root=env["project_root"],
+        implementer_runner=MockImplementerRunner(),
+        checks_runner=FakeChecksRunner(),
+        reviewer_runner=MockReviewerRunner(),
+        auditor_runner=MockAuditorRunner(),
+    )
+
+    async def raise_pipeline_error(job_id: str):
+        raise RuntimeError("pipeline broke token=should-not-leak")
+
+    pipeline.execute_queued_job = raise_pipeline_error
+    service = OrchestrationService(
+        in_memory_uow,
+        project_root=env["project_root"],
+        pipeline=pipeline,
+        github_adapter=FakeGitHubAdapter(),
+    )
+
+    run = service.start(env["project_id"], env["change_name"])
+
+    assert run.current_stage == OrchestrationStage.IMPLEMENTING
+    assert run.stop_outcome == OrchestrationStopOutcome.NEEDS_HUMAN
+    assert run.human_gate == HumanGate.NEEDS_HUMAN
+    assert run.is_active is False
+    assert run.stop_details == {
+        "code": "EXECUTION_PIPELINE_EXCEPTION",
+        "exception_type": "RuntimeError",
+        "error": "pipeline broke token=[REDACTED]",
+    }
+
+    job = in_memory_uow.jobs.get_by_id(run.active_job_id)
+    assert job is not None
+    assert job.status == JobStatus.QUEUED
+    assert job.candidate_sha is None
+    assert in_memory_uow.job_attempts.list_by_job(job.job_id) == []
+    assert in_memory_uow.check_results.list_by_job(job.job_id) == []
+    assert in_memory_uow.reviews.get_by_job_id(job.job_id) is None
+    assert in_memory_uow.audits.get_by_job_id(job.job_id) is None
+
+    events = in_memory_uow.orchestration_stage_events.list_by_run(run.run_id)
+    assert events[-1].event_type == "ORCHESTRATION_STOPPED"
+    assert not any(
+        event.to_stage
+        in {
+            OrchestrationStage.EVALUATING_ATTEMPT,
+            OrchestrationStage.RUNNING_CHECKS,
+        }
+        for event in events
+    )
+
+
 def test_orchestration_reuses_pipeline_evidence_after_production_worktree_cleanup(
     setup_orchestration_environment, in_memory_uow
 ):

--- a/tests/test_orchestration_postgres_integration.py
+++ b/tests/test_orchestration_postgres_integration.py
@@ -122,6 +122,49 @@ def test_active_run_partial_unique_index_allows_history_and_independent_changes(
         )
 
 
+def test_postgres_job_transitions_use_the_canonical_transition_map(
+    session_factory: sessionmaker[Session], project_id: str
+):
+    """Exercise the real PostgreSQL job repository against the disposable database."""
+    queued_job = Job(
+        project_id=project_id,
+        change_name=f"job-{uuid4().hex}",
+        implementer_role="codex",
+    )
+    waiting_job = queued_job.model_copy(
+        deep=True, update={"job_id": f"{queued_job.job_id}-waiting"}
+    )
+    recovery_job = queued_job.model_copy(
+        deep=True, update={"job_id": f"{queued_job.job_id}-recovery"}
+    )
+
+    with session_factory() as session:
+        uow = PostgresPersistenceUnitOfWork(session)
+        for job in (queued_job, waiting_job, recovery_job):
+            uow.jobs.save(job)
+        uow.commit()
+
+        assert uow.jobs.transition(queued_job.job_id, "RUNNING").status.value == "RUNNING"
+        uow.jobs.transition(waiting_job.job_id, "RUNNING")
+        assert (
+            uow.jobs.set_waiting_capacity(
+                waiting_job.job_id, "codex", "subscription exhausted"
+            ).status.value
+            == "WAITING_CAPACITY"
+        )
+        uow.jobs.transition(recovery_job.job_id, "RUNNING")
+        assert (
+            uow.jobs.set_recovery_blocked(
+                recovery_job.job_id, "runtime identity unavailable"
+            ).status.value
+            == "RECOVERY_BLOCKED"
+        )
+        with pytest.raises(ValueError, match="Invalid job status transition"):
+            uow.jobs.transition(queued_job.job_id, "READY_TO_MERGE")
+
+        session.rollback()
+
+
 def test_transition_and_external_action_keys_survive_new_sessions(
     session_factory: sessionmaker[Session], project_id: str
 ):


### PR DESCRIPTION
## Purpose

Bootstrap hotfix required before mini me can safely self-orchestrate OpenSpec change 010.

## Defects fixed

- Fixes PostgreSQL Job transition methods using the wrong transition-map attribute.
- Prevents unexpected execution-pipeline exceptions from advancing orchestration into evaluation/check stages.

## Verification

- Complementary review: READY_TO_FREEZE
- Safe suite: 302 passed, 5 skipped
- Ruff: PASS
- git diff --check: PASS
- Real PostgreSQL transition regression: PASS
- Disposable DB: minime_hotfix_verify
- Runtime DB user during evidence: minime_app
- Canonical DB minime was not used
- OpenSpec 010 planning untouched

## Candidate

`a2795f53abeaec139cd67e3e9607a696b3d64f3e`

## Scope

Bootstrap infrastructure only.
No OpenSpec 010 implementation.
No schema migration.
No provider/scheduler redesign.