### PR TITLE
fix: make CLI provider invocation configurable

### DIFF
--- a/config/minime.example.yaml
+++ b/config/minime.example.yaml
@@ -22,11 +22,25 @@ providers:
     command: codex
     enabled: true
     roles: [implementer, reviewer]
+    invocation:
+      implementer:
+        args: [exec, "-", --approve-for-me, --ephemeral]
+        prompt_transport: stdin
+      reviewer:
+        args: [exec, "-", --sandbox, read-only, --ask-for-approval, never, --ephemeral]
+        prompt_transport: stdin
   antigravity:
     type: cli
     command: agy
     enabled: true
     roles: [implementer, reviewer]
+    invocation:
+      implementer:
+        args: [--mode, accept-edits, "--print={prompt}"]
+        prompt_transport: argument
+      reviewer:
+        args: [--mode, plan, "--print={prompt}"]
+        prompt_transport: argument
   deepseek:
     type: openai-compatible-direct
     base_url: https://api.deepseek.com

--- a/config/minime.yaml
+++ b/config/minime.yaml
@@ -22,11 +22,25 @@ providers:
     command: codex
     enabled: true
     roles: [implementer, reviewer]
+    invocation:
+      implementer:
+        args: [exec, "-", --approve-for-me, --ephemeral]
+        prompt_transport: stdin
+      reviewer:
+        args: [exec, "-", --sandbox, read-only, --ask-for-approval, never, --ephemeral]
+        prompt_transport: stdin
   antigravity:
     type: cli
     command: agy
     enabled: true
     roles: [implementer, reviewer]
+    invocation:
+      implementer:
+        args: [--mode, accept-edits, "--print={prompt}"]
+        prompt_transport: argument
+      reviewer:
+        args: [--mode, plan, "--print={prompt}"]
+        prompt_transport: argument
   deepseek:
     type: openai-compatible-direct
     base_url: https://api.deepseek.com

--- a/src/minime/config.py
+++ b/src/minime/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -54,11 +55,17 @@ class SchedulerConfig(BaseModel):
     max_review_rounds: int = 2
 
 
+class CliInvocationConfig(BaseModel):
+    args: list[str] = Field(default_factory=list)
+    prompt_transport: str = "stdin"
+
+
 class ProviderConfig(BaseModel):
     type: str = "cli"
     command: str | None = None
     enabled: bool = True
     roles: list[str] = Field(default_factory=list)
+    invocation: dict[str, CliInvocationConfig] = Field(default_factory=dict)
     base_url: str | None = None
     api_key_env: str | None = None
     paid: bool = False
@@ -144,6 +151,58 @@ class AppConfig(BaseModel):
     github: GitHubConfig = Field(default_factory=GitHubConfig)
     security: SecurityConfig = Field(default_factory=SecurityConfig)
     projects: dict[str, ProjectConfig] = Field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CliInvocationProfile:
+    provider: str
+    role: str
+    executable: str
+    args: tuple[str, ...]
+    prompt_transport: str
+
+
+def resolve_cli_invocation(
+    provider: str, role: str, config: AppConfig | None = None
+) -> CliInvocationProfile:
+    """Resolve and validate one provider/role CLI invocation from app configuration."""
+    app_config = config or load_config()
+    provider_config = app_config.providers.get(provider)
+    if provider_config is None:
+        raise ValueError(f"CLI provider '{provider}' is not configured.")
+    if not provider_config.enabled:
+        raise ValueError(f"CLI provider '{provider}' is disabled.")
+    if provider_config.type != "cli":
+        raise ValueError(f"Provider '{provider}' is not configured as a CLI provider.")
+    if role not in provider_config.roles:
+        raise ValueError(f"Provider '{provider}' does not allow role '{role}'.")
+    executable = (provider_config.command or "").strip()
+    if not executable:
+        raise ValueError(f"CLI provider '{provider}' has no executable command configured.")
+    invocation = provider_config.invocation.get(role)
+    if invocation is None:
+        raise ValueError(f"CLI provider '{provider}' has no invocation profile for role '{role}'.")
+    if invocation.prompt_transport not in {"stdin", "argument"}:
+        raise ValueError(
+            f"Unsupported prompt transport '{invocation.prompt_transport}' for provider "
+            f"'{provider}' role '{role}'."
+        )
+    if any(not isinstance(arg, str) for arg in invocation.args):
+        raise ValueError(f"CLI provider '{provider}' has non-string invocation arguments.")
+    if invocation.prompt_transport == "argument" and not any(
+        "{prompt}" in arg for arg in invocation.args
+    ):
+        raise ValueError(
+            f"CLI provider '{provider}' argument transport requires a '{{prompt}}' argument "
+            f"for role '{role}'."
+        )
+    return CliInvocationProfile(
+        provider=provider,
+        role=role,
+        executable=executable,
+        args=tuple(invocation.args),
+        prompt_transport=invocation.prompt_transport,
+    )
 
 
 def load_config(config_path: str | Path | None = None) -> AppConfig:

--- a/src/minime/services/execution_pipeline.py
+++ b/src/minime/services/execution_pipeline.py
@@ -588,6 +588,7 @@ class ExecutionPipelineService:
                         self._log(job.job_id, "stdout", line)
                     for line in result.stderr:
                         self._log(job.job_id, "stderr", line)
+                    self.uow.commit()
 
                     self.uow.metrics.save(
                         MetricFact(
@@ -1383,6 +1384,7 @@ class ExecutionPipelineService:
                     self._log(job.job_id, "stdout", line)
                 for line in review_result.stderr:
                     self._log(job.job_id, "stderr", line)
+                self.uow.commit()
 
                 self.uow.metrics.save(
                     MetricFact(

--- a/src/minime/services/implementer_runner.py
+++ b/src/minime/services/implementer_runner.py
@@ -10,6 +10,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from minime.config import AppConfig, CliInvocationProfile, resolve_cli_invocation
 from minime.logging import redact_secrets
 
 logger = logging.getLogger(__name__)
@@ -32,15 +33,33 @@ class ImplementerRunnerInterface:
 
 
 class CliImplementerRunner(ImplementerRunnerInterface):
-    def __init__(self, command: list[str]):
-        self.command = command
+    MAX_OUTPUT_LINES = 2000
+    MAX_LINE_CHARS = 4000
+
+    def __init__(self, invocation: CliInvocationProfile | list[str]):
+        if isinstance(invocation, CliInvocationProfile):
+            if invocation.prompt_transport not in {"stdin", "argument"}:
+                raise ValueError(f"Unsupported prompt transport '{invocation.prompt_transport}'.")
+            self.profile = invocation
+            self.command = [invocation.executable, *invocation.args]
+        else:
+            self.profile = None
+            self.command = invocation
+
+    def _command_for_prompt(self, prompt_context: str) -> list[str]:
+        if self.profile and self.profile.prompt_transport == "argument":
+            return [
+                self.profile.executable,
+                *(arg.replace("{prompt}", prompt_context) for arg in self.profile.args),
+            ]
+        return self.command
 
     async def run(
         self, worktree_path: Path, prompt_context: str, timeout_seconds: int
     ) -> ImplementerResult:
         start = asyncio.get_running_loop().time()
         proc = await asyncio.create_subprocess_exec(
-            *self.command,
+            *self._command_for_prompt(prompt_context),
             cwd=str(worktree_path),
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -50,7 +69,11 @@ class CliImplementerRunner(ImplementerRunnerInterface):
         timed_out = False
         try:
             stdout, stderr = await asyncio.wait_for(
-                proc.communicate(prompt_context.encode()),
+                proc.communicate(
+                    prompt_context.encode()
+                    if not self.profile or self.profile.prompt_transport == "stdin"
+                    else None
+                ),
                 timeout=timeout_seconds,
             )
         except asyncio.TimeoutError:
@@ -65,10 +88,15 @@ class CliImplementerRunner(ImplementerRunnerInterface):
         return ImplementerResult(
             exit_code=proc.returncode if proc.returncode is not None else -1,
             timed_out=timed_out,
-            stdout=[redact_secrets(line) for line in stdout.decode(errors="replace").splitlines()],
-            stderr=[redact_secrets(line) for line in stderr.decode(errors="replace").splitlines()],
+            stdout=self._sanitize_output(stdout),
+            stderr=self._sanitize_output(stderr),
             duration_ms=duration_ms,
         )
+
+    @classmethod
+    def _sanitize_output(cls, output: bytes) -> list[str]:
+        lines = output.decode(errors="replace").splitlines()[: cls.MAX_OUTPUT_LINES]
+        return [redact_secrets(line[: cls.MAX_LINE_CHARS]) for line in lines]
 
 
 class MockImplementerRunner(ImplementerRunnerInterface):
@@ -128,6 +156,7 @@ class MockImplementerRunner(ImplementerRunnerInterface):
         )
 
 
-def runner_for_implementer(implementer: str) -> ImplementerRunnerInterface:
-    command = "codex" if implementer.lower() == "codex" else "agy"
-    return CliImplementerRunner([command])
+def runner_for_implementer(
+    implementer: str, config: AppConfig | None = None
+) -> ImplementerRunnerInterface:
+    return CliImplementerRunner(resolve_cli_invocation(implementer, "implementer", config))

--- a/src/minime/services/reviewer_runner.py
+++ b/src/minime/services/reviewer_runner.py
@@ -8,6 +8,7 @@ import signal
 from dataclasses import dataclass
 from pathlib import Path
 
+from minime.config import AppConfig, CliInvocationProfile, resolve_cli_invocation
 from minime.logging import redact_secrets
 
 
@@ -28,15 +29,33 @@ class ReviewerRunnerInterface:
 
 
 class CliReviewerRunner(ReviewerRunnerInterface):
-    def __init__(self, command: list[str]):
-        self.command = command
+    MAX_OUTPUT_LINES = 2000
+    MAX_LINE_CHARS = 4000
+
+    def __init__(self, invocation: CliInvocationProfile | list[str]):
+        if isinstance(invocation, CliInvocationProfile):
+            if invocation.prompt_transport not in {"stdin", "argument"}:
+                raise ValueError(f"Unsupported prompt transport '{invocation.prompt_transport}'.")
+            self.profile = invocation
+            self.command = [invocation.executable, *invocation.args]
+        else:
+            self.profile = None
+            self.command = invocation
+
+    def _command_for_prompt(self, prompt_context: str) -> list[str]:
+        if self.profile and self.profile.prompt_transport == "argument":
+            return [
+                self.profile.executable,
+                *(arg.replace("{prompt}", prompt_context) for arg in self.profile.args),
+            ]
+        return self.command
 
     async def run(
         self, worktree_path: Path, prompt_context: str, timeout_seconds: int
     ) -> ReviewerResult:
         start = asyncio.get_running_loop().time()
         proc = await asyncio.create_subprocess_exec(
-            *self.command,
+            *self._command_for_prompt(prompt_context),
             cwd=str(worktree_path),
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -46,7 +65,11 @@ class CliReviewerRunner(ReviewerRunnerInterface):
         timed_out = False
         try:
             stdout, stderr = await asyncio.wait_for(
-                proc.communicate(prompt_context.encode()),
+                proc.communicate(
+                    prompt_context.encode()
+                    if not self.profile or self.profile.prompt_transport == "stdin"
+                    else None
+                ),
                 timeout=timeout_seconds,
             )
         except asyncio.TimeoutError:
@@ -61,10 +84,15 @@ class CliReviewerRunner(ReviewerRunnerInterface):
         return ReviewerResult(
             exit_code=proc.returncode if proc.returncode is not None else -1,
             timed_out=timed_out,
-            stdout=[redact_secrets(line) for line in stdout.decode(errors="replace").splitlines()],
-            stderr=[redact_secrets(line) for line in stderr.decode(errors="replace").splitlines()],
+            stdout=self._sanitize_output(stdout),
+            stderr=self._sanitize_output(stderr),
             duration_ms=duration_ms,
         )
+
+    @classmethod
+    def _sanitize_output(cls, output: bytes) -> list[str]:
+        lines = output.decode(errors="replace").splitlines()[: cls.MAX_OUTPUT_LINES]
+        return [redact_secrets(line[: cls.MAX_LINE_CHARS]) for line in lines]
 
 
 class MockReviewerRunner(ReviewerRunnerInterface):
@@ -93,6 +121,7 @@ class MockReviewerRunner(ReviewerRunnerInterface):
         )
 
 
-def runner_for_reviewer(reviewer: str) -> ReviewerRunnerInterface:
-    command = "codex" if reviewer.lower() == "codex" else "agy"
-    return CliReviewerRunner([command])
+def runner_for_reviewer(
+    reviewer: str, config: AppConfig | None = None
+) -> ReviewerRunnerInterface:
+    return CliReviewerRunner(resolve_cli_invocation(reviewer, "reviewer", config))

--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -5,7 +5,13 @@ import logging
 
 import pytest
 
-from minime.config import DatabaseConfig
+from minime.config import (
+    AppConfig,
+    CliInvocationConfig,
+    DatabaseConfig,
+    ProviderConfig,
+    resolve_cli_invocation,
+)
 from minime.db.session import validate_postgres_url
 from minime.logging import (
     StructuredJsonFormatter,
@@ -61,6 +67,74 @@ def test_secret_redaction(monkeypatch):
 
 def test_correlation_context_and_json_logging():
     clear_correlation_context()
+
+
+def test_cli_invocation_profiles_resolve_without_provider_specific_runner_logic():
+    config = AppConfig(
+        providers={
+            "test-cli": ProviderConfig(
+                command="future-runner",
+                roles=["implementer", "reviewer"],
+                invocation={
+                    "implementer": CliInvocationConfig(
+                        args=["--edit", "--input", "-"], prompt_transport="stdin"
+                    ),
+                    "reviewer": CliInvocationConfig(
+                        args=["--review", "--input", "-"], prompt_transport="stdin"
+                    ),
+                },
+            )
+        }
+    )
+
+    implementer = resolve_cli_invocation("test-cli", "implementer", config)
+    reviewer = resolve_cli_invocation("test-cli", "reviewer", config)
+
+    assert (implementer.executable, implementer.args) == (
+        "future-runner",
+        ("--edit", "--input", "-"),
+    )
+    assert reviewer.args == ("--review", "--input", "-")
+
+
+@pytest.mark.parametrize(
+    ("provider", "role", "message"),
+    [
+        ("missing", "implementer", "not configured"),
+        ("disabled", "implementer", "disabled"),
+        ("test-cli", "auditor", "does not allow role"),
+        ("test-cli", "reviewer", "no invocation profile"),
+    ],
+)
+def test_cli_invocation_resolution_fails_closed(provider, role, message):
+    config = AppConfig(
+        providers={
+            "disabled": ProviderConfig(enabled=False),
+            "test-cli": ProviderConfig(
+                command="runner",
+                roles=["implementer", "reviewer"],
+                invocation={"implementer": CliInvocationConfig()},
+            )
+        }
+    )
+    with pytest.raises(ValueError, match=message):
+        resolve_cli_invocation(provider, role, config)
+
+
+def test_cli_invocation_rejects_unsupported_prompt_transport():
+    config = AppConfig(
+        providers={
+            "test-cli": ProviderConfig(
+                command="runner",
+                roles=["implementer"],
+                invocation={
+                    "implementer": CliInvocationConfig(prompt_transport="file")
+                },
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="Unsupported prompt transport"):
+        resolve_cli_invocation("test-cli", "implementer", config)
     assert get_correlation_context() == {
         "project_id": None,
         "change_id": None,

--- a/tests/test_worktree_and_runner.py
+++ b/tests/test_worktree_and_runner.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import pytest
 
 from minime.adapters.github import GitHubAdapter
-from minime.services.implementer_runner import CliImplementerRunner
+from minime.config import AppConfig, CliInvocationConfig, ProviderConfig, load_config
+from minime.services.implementer_runner import CliImplementerRunner, runner_for_implementer
+from minime.services.reviewer_runner import CliReviewerRunner, runner_for_reviewer
 from minime.services.worktree_manager import WorktreeManager
 
 
@@ -161,3 +163,75 @@ async def test_cli_implementer_runner_redacts_output_and_times_out(tmp_path):
 
     assert timeout_result.timed_out is True
     assert timeout_result.exit_code != 0
+
+
+def test_configured_cli_profiles_build_generic_implementer_and_reviewer_vectors():
+    config = AppConfig(
+        providers={
+            "codex": ProviderConfig(
+                command="codex",
+                roles=["implementer", "reviewer"],
+                invocation={
+                    "implementer": CliInvocationConfig(
+                        args=["exec", "-", "--sandbox", "workspace-write"]
+                    ),
+                    "reviewer": CliInvocationConfig(
+                        args=["exec", "-", "--sandbox", "read-only"]
+                    ),
+                },
+            ),
+            "future-cli": ProviderConfig(
+                command="future",
+                roles=["implementer"],
+                invocation={
+                    "implementer": CliInvocationConfig(args=["run", "--headless"])
+                },
+            ),
+        }
+    )
+
+    implementer = runner_for_implementer("codex", config)
+    reviewer = runner_for_reviewer("codex", config)
+    future = runner_for_implementer("future-cli", config)
+
+    assert isinstance(implementer, CliImplementerRunner)
+    assert implementer.command == ["codex", "exec", "-", "--sandbox", "workspace-write"]
+    assert isinstance(reviewer, CliReviewerRunner)
+    assert reviewer.command == ["codex", "exec", "-", "--sandbox", "read-only"]
+    assert future.command == ["future", "run", "--headless"]
+
+
+def test_known_headless_cli_contracts_are_configured():
+    config = load_config("config/minime.yaml")
+
+    assert runner_for_implementer("codex", config).command == [
+        "codex",
+        "exec",
+        "-",
+        "--approve-for-me",
+        "--ephemeral",
+    ]
+    assert runner_for_implementer("antigravity", config).command == [
+        "agy",
+        "--mode",
+        "accept-edits",
+        "--print={prompt}",
+    ]
+    assert runner_for_reviewer("antigravity", config).command == [
+        "agy",
+        "--mode",
+        "plan",
+        "--print={prompt}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cli_runner_bounds_sanitized_output(tmp_path):
+    output_runner = CliImplementerRunner(
+        [sys.executable, "-c", "print('token=secret123'); print('x' * 5000)"]
+    )
+    result = await output_runner.run(tmp_path, "prompt", timeout_seconds=5)
+
+    assert len(result.stdout) == 2
+    assert "secret123" not in result.stdout[0]
+    assert len(result.stdout[1]) == output_runner.MAX_LINE_CHARS


### PR DESCRIPTION
## Purpose

Bootstrap runtime hotfix required before retrying autonomous orchestration of OpenSpec change 010.

## Defect fixed

mini me hardcoded Codex/Antigravity CLI invocation instead of using provider configuration.

The runtime now resolves CLI invocation from configuration:

- executable/command
- role-specific args
- explicit prompt transport
- enabled state
- role authorization

Implementer and reviewer use the same generic configuration-driven mechanism.

## Extensibility

Future CLI providers can be added through configuration without provider-name branching in orchestration or runner logic.

## Current provider contracts

Codex:
- headless non-interactive execution
- stdin prompt transport
- independent implementer/reviewer profiles

Antigravity:
- headless print mode
- independent implementer/reviewer profiles
- local file-edit permission remains an operator-environment prerequisite
- no dangerous permission bypass flags embedded in repository config

## Observability

Provider stdout/stderr JobLogs are now:
- durably committed
- secret-redacted
- bounded

## Verification

- Complementary review: READY_TO_FREEZE
- Focused tests: 21 passed
- Full safe suite: 313 passed, 5 skipped
- Ruff: PASS
- git diff --check: PASS
- Codex disposable live probe: PASS
- Antigravity invocation contract: PASS; edit denied by local operator permission policy
- OpenSpec 010 untouched
- No migration
- No scheduler/provider-health redesign

## Candidate

`e9e8634e8a61cf0fbdac5e6fce485ef416ca9e45`

## Scope

Bootstrap provider-runtime infrastructure only.
No OpenSpec 010 implementation.