### PR TITLE
fix: bind implementer prompts to candidate workspace

### DIFF
--- a/src/minime/services/execution_pipeline.py
+++ b/src/minime/services/execution_pipeline.py
@@ -92,6 +92,21 @@ from minime.services.worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
 
+
+def format_candidate_workspace_context(worktree_path: str | Path) -> str:
+    """Build the provider-agnostic workspace boundary for an implementer attempt."""
+    resolved_path = Path(worktree_path).resolve()
+    return "\n".join(
+        [
+            "CANDIDATE WORKSPACE",
+            f"Absolute path: {resolved_path}",
+            "",
+            "Treat this path as the authoritative candidate workspace for this attempt.",
+            "Perform all repository reads, writes, edits, and generated implementation artifacts inside this workspace only.",
+            "Do not write candidate files to provider scratch directories, another checkout, or the parent repository root.",
+        ]
+    )
+
 EVENT_BY_STATUS = {
     JobStatus.QUEUED: EventType.JOB_QUEUED,
     JobStatus.RUNNING: EventType.JOB_RUNNING,
@@ -371,11 +386,16 @@ class ExecutionPipelineService:
                     self.handoff_manager.consume_handoff(
                         latest_handoff.handoff_id, attempt_id, self.uow
                     )
-                    handoff_prompt = self.handoff_manager.format_handoff_prompt(latest_handoff)
+                    handoff_prompt = self.handoff_manager.format_handoff_prompt(
+                        latest_handoff, authoritative_worktree_path=worktree.path.resolve()
+                    )
 
-                prompt_context = worktree_task_tracker.format_prompt_context(
+                workspace_path = worktree.path.resolve()
+                workspace_context = format_candidate_workspace_context(workspace_path)
+                task_context = worktree_task_tracker.format_prompt_context(
                     project.openspec_path, job.change_name
                 )
+                prompt_context = f"{workspace_context}\n\n{task_context}"
                 if handoff_prompt:
                     prompt_context = f"{prompt_context}\n\n{handoff_prompt}"
                 if corrective_prompt:
@@ -864,7 +884,7 @@ class ExecutionPipelineService:
                         from_attempt_id=attempt_id,
                         from_executor=current_executor,
                         to_executor=target_executor,
-                        worktree_path=str(worktree.path),
+                        worktree_path=str(worktree.path.resolve()),
                         base_sha=job.base_sha or "",
                         candidate_sha=current_sha,
                         completed_tasks=completed_tasks,

--- a/src/minime/services/handoff_manager.py
+++ b/src/minime/services/handoff_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from minime.domain.interfaces import PersistenceUnitOfWork
@@ -130,14 +131,21 @@ class HandoffManager:
         uow.job_handoffs.save(handoff)
         return handoff
 
-    def format_handoff_prompt(self, handoff: JobHandoff) -> str:
+    def format_handoff_prompt(
+        self, handoff: JobHandoff, authoritative_worktree_path: str | Path | None = None
+    ) -> str:
         """Generate formatted prompt context for the incoming executor."""
+        worktree_path = (
+            Path(authoritative_worktree_path).resolve()
+            if authoritative_worktree_path is not None
+            else handoff.worktree_path
+        )
         lines = [
             "==================================================",
             "HANDOFF CONTEXT FROM PREVIOUS EXECUTOR",
             "==================================================",
             f"Prior Executor: {handoff.from_executor}",
-            f"Worktree Path: {handoff.worktree_path}",
+            f"Worktree Path: {worktree_path}",
             f"Base SHA: {handoff.base_sha}",
             f"Candidate SHA: {handoff.candidate_sha}",
             "",

--- a/tests/test_continuation_pipeline_integration.py
+++ b/tests/test_continuation_pipeline_integration.py
@@ -344,6 +344,12 @@ async def test_continuation_pipeline_multi_attempt_success(tmp_path: Path):
     assert res_job.attempt_count == 2
     assert len(uow._attempts) == 2
     assert res_job.latest_outcome == ExecutionOutcome.COMPLETED
+    prompts = [call.args[1] for call in mock_imp_runner.run.call_args_list]
+    assert len(prompts) == 2
+    for prompt in prompts:
+        assert f"Absolute path: {mock_worktree.path.resolve()}" in prompt
+        assert "all repository reads, writes, edits" in prompt
+        assert "provider scratch directories" in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_pipeline.py
+++ b/tests/test_execution_pipeline.py
@@ -8,12 +8,48 @@ from pathlib import Path
 import pytest
 
 from minime.domain.enums import ChangeStatus, EventType, JobStatus, ReadinessState
-from minime.domain.models import Change, Project
+from minime.domain.models import Change, JobHandoff, Project
 from minime.services.deepseek_auditor_runner import MockAuditorRunner
-from minime.services.execution_pipeline import ExecutionPipelineService
+from minime.services.execution_pipeline import (
+    ExecutionPipelineService,
+    format_candidate_workspace_context,
+)
+from minime.services.handoff_manager import HandoffManager
 from minime.services.implementer_runner import MockImplementerRunner
+from minime.services.openspec_tasks import OpenSpecTaskTracker
 from minime.services.reviewer_runner import MockReviewerRunner
 from minime.services.worktree_manager import WorktreeInfo
+
+
+def test_workspace_context_is_absolute_and_openspec_tracker_stays_task_focused(tmp_path):
+    relative_path = Path("relative-candidate-workspace")
+    context = format_candidate_workspace_context(relative_path)
+
+    assert f"Absolute path: {relative_path.resolve()}" in context
+    assert "all repository reads, writes, edits" in context
+    assert "provider scratch directories" in context
+
+    tracker = OpenSpecTaskTracker(tmp_path)
+    task_context = tracker.format_prompt_context("openspec", "missing-change")
+    assert "CANDIDATE WORKSPACE" not in task_context
+
+
+def test_handoff_prompt_normalizes_to_authoritative_workspace(tmp_path):
+    handoff = JobHandoff(
+        job_id="job-1",
+        from_attempt_id="attempt-1",
+        from_executor="one",
+        to_executor="two",
+        worktree_path="relative/stale-worktree",
+        base_sha="base",
+        candidate_sha="candidate",
+    )
+    prompt = HandoffManager().format_handoff_prompt(
+        handoff, authoritative_worktree_path=tmp_path / "candidate"
+    )
+
+    assert f"Worktree Path: {(tmp_path / 'candidate').resolve()}" in prompt
+    assert "relative/stale-worktree" not in prompt
 
 
 class FakeWorktreeManager:


### PR DESCRIPTION
## Purpose

Bootstrap runtime hotfix required before retrying autonomous orchestration of OpenSpec change 010.

## Defect fixed

The implementer process was launched with the correct candidate worktree as cwd, but the first attempt prompt did not explicitly identify the authoritative workspace.

This was material for Antigravity headless behavior: relative native edits could fall back to its scratch directory, while explicit absolute workspace paths correctly targeted the candidate repository.

## Change

Every implementer attempt now receives a provider-agnostic CANDIDATE WORKSPACE block containing:

- the resolved absolute candidate workspace path;
- explicit instruction to perform repository reads/writes/edits inside that workspace;
- explicit instruction not to write candidate artifacts to provider scratch, another checkout, or the parent repository root.

The same context applies to:

- first attempt;
- corrective retries;
- reassignment;
- handoff continuation.

Persisted handoff worktree paths are normalized consistently without rewriting historical evidence.

## Architecture

No provider-specific logic was added.

No Codex/Antigravity/Cursor branching exists in workspace context handling.

OpenSpecTaskTracker remains task-focused.

## Verification

- Complementary review: READY_TO_FREEZE
- Focused tests: 18 passed
- Full safe suite: 315 passed, 5 skipped
- Ruff: PASS
- git diff --check: PASS
- OpenSpec 010 untouched
- No migration
- No provider config/CLI flag changes

## Candidate

`40d2923fd39bf2887f7ccaed417b702252d23d7e`

## Scope

Bootstrap execution-context infrastructure only.
No OpenSpec 010 implementation.