### PR TITLE
fix: enforce logical change identity

### DIFF
--- a/alembic/versions/008b_change_identity.py
+++ b/alembic/versions/008b_change_identity.py
@@ -1,0 +1,144 @@
+"""Deduplicate changes and enforce project/name logical identity.
+
+The upgrade keeps the earliest physical row in each duplicate group, copies the
+most authoritative mutable state to it, and removes redundant rows.  Downgrade
+is schema-only: deleted duplicate rows are intentionally not recreated.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import context, op
+
+revision: str = "008b_change_identity"
+down_revision: Union[str, None] = "008_autonomous_orchestration"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_REQUIRED_FIELDS = (
+    "id",
+    "project_id",
+    "name",
+    "status",
+    "schema_name",
+    "specs_paths",
+    "last_readiness_status",
+    "last_readiness_reasons",
+    "discovered_at",
+    "updated_at",
+)
+
+
+_VALID_READINESS_BY_STATUS = {
+    "DISCOVERED": {"NOT_READY"},
+    "READY": {"READY"},
+    # These lifecycle states represent work that passed readiness; BLOCKED has
+    # its own explicit readiness state in the domain model.
+    "IN_PROGRESS": {"READY"},
+    "DONE": {"READY"},
+    "CANCELLED": {"READY"},
+    "BLOCKED": {"BLOCKED"},
+}
+
+
+def _validate_consistency(row: sa.RowMapping) -> None:
+    status = row["status"]
+    readiness = row["last_readiness_status"]
+    if readiness not in _VALID_READINESS_BY_STATUS.get(status, set()):
+        raise RuntimeError(
+            "Cannot reconcile contradictory Change state: "
+            f"project_id={row['project_id']!r}, name={row['name']!r}, id={row['id']!r}, "
+            f"status={status!r}, readiness={readiness!r}"
+        )
+
+
+def _quality(row: sa.RowMapping) -> int:
+    return int(row["status"] == "READY" and row["last_readiness_status"] == "READY")
+
+
+def upgrade() -> None:
+    if context.is_offline_mode():
+        op.create_unique_constraint(
+            "uq_changes_project_name", "changes", ["project_id", "name"]
+        )
+        return
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text(
+            "SELECT id, project_id, name, status, stage, schema_name, proposal_path, "
+            "tasks_path, design_path, specs_paths, last_readiness_status, "
+            "last_readiness_reasons, discovered_at, updated_at "
+            "FROM changes ORDER BY project_id, name, discovered_at, id"
+        )
+    ).mappings().all()
+
+    groups: dict[tuple[str, str], list[sa.RowMapping]] = {}
+    for row in rows:
+        if any(row[field] is None for field in _REQUIRED_FIELDS):
+            raise RuntimeError(
+                f"Cannot reconcile changes row {row.get('id')!r}: required data is NULL"
+            )
+        _validate_consistency(row)
+        groups.setdefault((row["project_id"], row["name"]), []).append(row)
+
+    update_sql = sa.text(
+        "UPDATE changes SET status = :status, stage = :stage, schema_name = :schema_name, "
+        "proposal_path = :proposal_path, tasks_path = :tasks_path, design_path = :design_path, "
+        "specs_paths = :specs_paths, last_readiness_status = :last_readiness_status, "
+        "last_readiness_reasons = :last_readiness_reasons, discovered_at = :discovered_at, "
+        "updated_at = :updated_at WHERE id = :survivor_id"
+    ).bindparams(
+        sa.bindparam("specs_paths", type_=sa.JSON),
+        sa.bindparam("last_readiness_reasons", type_=sa.JSON),
+    )
+    delete_sql = sa.text("DELETE FROM changes WHERE id = :id")
+
+    for (project_id, name), group in groups.items():
+        if len(group) < 2:
+            continue
+        survivor = min(group, key=lambda row: (row["discovered_at"], row["id"]))
+        authoritative = max(
+            group,
+            key=lambda row: (
+                _quality(row),
+                row["updated_at"],
+            ),
+        )
+        tied = [
+            row
+            for row in group
+            if (
+                _quality(row) == _quality(authoritative)
+                and row["updated_at"] == authoritative["updated_at"]
+            )
+        ]
+        authoritative = min(tied, key=lambda row: row["id"])
+        connection.execute(
+            update_sql,
+            {
+                "survivor_id": survivor["id"],
+                "status": authoritative["status"],
+                "stage": authoritative["stage"],
+                "schema_name": authoritative["schema_name"],
+                "proposal_path": authoritative["proposal_path"],
+                "tasks_path": authoritative["tasks_path"],
+                "design_path": authoritative["design_path"],
+                "specs_paths": authoritative["specs_paths"],
+                "last_readiness_status": authoritative["last_readiness_status"],
+                "last_readiness_reasons": authoritative["last_readiness_reasons"],
+                "discovered_at": survivor["discovered_at"],
+                "updated_at": authoritative["updated_at"],
+            },
+        )
+        for row in group:
+            if row["id"] != survivor["id"]:
+                connection.execute(delete_sql, {"id": row["id"]})
+
+    op.create_unique_constraint("uq_changes_project_name", "changes", ["project_id", "name"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_changes_project_name", "changes", type_="unique")

--- a/src/minime/db/models.py
+++ b/src/minime/db/models.py
@@ -102,6 +102,8 @@ class ProjectBindingModel(Base):
 class ChangeModel(Base):
     __tablename__ = "changes"
 
+    __table_args__ = (UniqueConstraint("project_id", "name", name="uq_changes_project_name"),)
+
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     project_id: Mapped[str] = mapped_column(
         String(64), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True

--- a/src/minime/db/repository.py
+++ b/src/minime/db/repository.py
@@ -721,9 +721,30 @@ class PostgresChangeRepository(ChangeRepositoryInterface):
         self.session = session
 
     def save(self, change: Change) -> None:
-        existing = self.session.get(ChangeModel, change.change_id)
-        if existing:
+        physical = self.session.get(ChangeModel, change.change_id)
+        logical_matches = self.session.scalars(
+            select(ChangeModel).where(
+                ChangeModel.project_id == change.project_id, ChangeModel.name == change.name
+            )
+        ).all()
+        if len(logical_matches) > 1:
+            raise ValueError(
+                f"Ambiguous logical Change identity for project '{change.project_id}' and "
+                f"change '{change.name}': {len(logical_matches)} rows found."
+            )
+        if physical is not None and logical_matches and logical_matches[0].id != physical.id:
+            raise ValueError(
+                f"Conflicting Change identities: physical id '{change.change_id}' does not "
+                f"match the logical row for project '{change.project_id}' and change "
+                f"'{change.name}'."
+            )
+        if physical:
+            # A loaded domain entity carries an explicit lifecycle update.  Its
+            # physical identity and original discovery timestamp are immutable,
+            # but all caller-provided mutable state must be persisted.
+            existing = physical
             existing.name = change.name
+            existing.project_id = change.project_id
             existing.status = change.status.value
             existing.stage = change.stage
             existing.schema_name = change.schema_name
@@ -733,6 +754,16 @@ class PostgresChangeRepository(ChangeRepositoryInterface):
             existing.specs_paths = change.specs_paths
             existing.last_readiness_status = change.last_readiness_status.value
             existing.last_readiness_reasons = change.last_readiness_reasons
+            existing.updated_at = change.updated_at
+        elif logical_matches:
+            # An unattached discovery object refreshes filesystem metadata but
+            # must not regress the durable lifecycle/readiness state.
+            existing = logical_matches[0]
+            existing.schema_name = change.schema_name
+            existing.proposal_path = change.proposal_path
+            existing.tasks_path = change.tasks_path
+            existing.design_path = change.design_path
+            existing.specs_paths = change.specs_paths
             existing.updated_at = change.updated_at
         else:
             model = ChangeModel(
@@ -761,8 +792,13 @@ class PostgresChangeRepository(ChangeRepositoryInterface):
         stmt = select(ChangeModel).where(
             ChangeModel.project_id == project_id, ChangeModel.name == name
         )
-        model = self.session.scalars(stmt).first()
-        return change_model_to_domain(model) if model else None
+        models = self.session.scalars(stmt).all()
+        if len(models) > 1:
+            raise ValueError(
+                f"Ambiguous logical Change identity for project '{project_id}' and change "
+                f"'{name}': {len(models)} rows found."
+            )
+        return change_model_to_domain(models[0]) if models else None
 
     def list_by_project(self, project_id: str) -> list[Change]:
         stmt = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,17 +112,60 @@ class InMemoryChangeRepository(ChangeRepositoryInterface):
         self._store: dict[str, Change] = {}
 
     def save(self, change: Change) -> None:
-        self._store[change.change_id] = change.model_copy(deep=True)
+        logical_matches = [
+            c
+            for c in self._store.values()
+            if c.project_id == change.project_id and c.name == change.name
+        ]
+        if len(logical_matches) > 1:
+            raise ValueError(
+                f"Ambiguous logical Change identity for project '{change.project_id}' and "
+                f"change '{change.name}': {len(logical_matches)} rows found."
+            )
+        physical = self._store.get(change.change_id)
+        if (
+            physical is not None
+            and logical_matches
+            and logical_matches[0].change_id != physical.change_id
+        ):
+            raise ValueError(
+                f"Conflicting Change identities for project '{change.project_id}' and "
+                f"change '{change.name}'."
+            )
+        if physical is not None:
+            updated = change.model_copy(deep=True)
+            updated.change_id = physical.change_id
+            updated.discovered_at = physical.discovered_at
+            self._store[physical.change_id] = updated
+            return
+        if logical_matches:
+            existing = logical_matches[0]
+            updated = existing.model_copy(deep=True)
+            updated.schema_name = change.schema_name
+            updated.proposal_path = change.proposal_path
+            updated.tasks_path = change.tasks_path
+            updated.design_path = change.design_path
+            updated.specs_paths = change.specs_paths
+            updated.updated_at = change.updated_at
+            self._store[existing.change_id] = updated
+            return
+        else:
+            self._store[change.change_id] = change.model_copy(deep=True)
 
     def get_by_id(self, change_id: str) -> Change | None:
         c = self._store.get(change_id)
         return c.model_copy(deep=True) if c else None
 
     def get_by_name(self, project_id: str, name: str) -> Change | None:
-        for c in self._store.values():
-            if c.project_id == project_id and c.name == name:
-                return c.model_copy(deep=True)
-        return None
+        matches = [
+            c for c in self._store.values() if c.project_id == project_id and c.name == name
+        ]
+        if len(matches) > 1:
+            raise ValueError(
+                f"Ambiguous logical Change identity for project '{project_id}' and change "
+                f"'{name}': {len(matches)} rows found."
+            )
+        return matches[0].model_copy(deep=True) if matches else None
 
     def list_by_project(self, project_id: str) -> list[Change]:
         return [c.model_copy(deep=True) for c in self._store.values() if c.project_id == project_id]

--- a/tests/test_change_identity_migration.py
+++ b/tests/test_change_identity_migration.py
@@ -1,0 +1,35 @@
+"""Focused unit checks for migration reconciliation guards."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MIGRATION_PATH = Path(__file__).parents[1] / "alembic/versions/008b_change_identity.py"
+_SPEC = importlib.util.spec_from_file_location("change_identity_migration", _MIGRATION_PATH)
+migration = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(migration)
+
+
+def row(**values):
+    return {
+        "id": "row-id",
+        "project_id": "mini-me",
+        "name": "synthetic",
+        "status": "DISCOVERED",
+        "last_readiness_status": "NOT_READY",
+        **values,
+    }
+
+
+def test_migration_allows_nullable_stage():
+    assert "stage" not in migration._REQUIRED_FIELDS
+    migration._validate_consistency(row(stage=None))
+
+
+def test_migration_rejects_contradictory_ready_state():
+    with pytest.raises(RuntimeError, match="project_id=.*status='READY'.*readiness='NOT_READY'"):
+        migration._validate_consistency(
+            row(status="READY", last_readiness_status="NOT_READY")
+        )

--- a/tests/test_change_logical_identity.py
+++ b/tests/test_change_logical_identity.py
@@ -1,0 +1,136 @@
+"""Regression coverage for logical OpenSpec change identity."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session
+
+from minime.db.models import Base, ChangeModel, ProjectModel
+from minime.db.repository import PostgresChangeRepository
+from minime.domain.enums import ChangeStatus, ProjectStatus, ReadinessState
+from minime.domain.models import Change
+
+
+def make_change(**kwargs):
+    now = datetime.now(UTC)
+    values = {
+        "project_id": "mini-me",
+        "name": "010-logical-identity",
+        "discovered_at": now,
+        "updated_at": now,
+    }
+    values.update(kwargs)
+    return Change(**values)
+
+
+def test_in_memory_rediscovery_is_logical_upsert_and_preserves_ready(in_memory_uow):
+    first = make_change(
+        change_id="stable-id",
+        status=ChangeStatus.READY,
+        last_readiness_status=ReadinessState.READY,
+        proposal_path="old/proposal.md",
+    )
+    in_memory_uow.changes.save(first)
+    rediscovered = make_change(
+        change_id="new-discovery-id",
+        status=ChangeStatus.DISCOVERED,
+        last_readiness_status=ReadinessState.NOT_READY,
+        proposal_path="new/proposal.md",
+        discovered_at=first.discovered_at + timedelta(days=1),
+    )
+    in_memory_uow.changes.save(rediscovered)
+
+    saved = in_memory_uow.changes.get_by_name("mini-me", "010-logical-identity")
+    assert saved is not None
+    assert saved.change_id == "stable-id"
+    assert saved.discovered_at == first.discovered_at
+    assert saved.proposal_path == "new/proposal.md"
+    assert saved.status == ChangeStatus.READY
+    assert saved.last_readiness_status == ReadinessState.READY
+
+
+def test_in_memory_attached_entity_can_regress_readiness(in_memory_uow):
+    first = make_change(
+        change_id="attached-id",
+        status=ChangeStatus.READY,
+        last_readiness_status=ReadinessState.READY,
+    )
+    in_memory_uow.changes.save(first)
+    loaded = in_memory_uow.changes.get_by_name(first.project_id, first.name)
+    loaded.status = ChangeStatus.DISCOVERED
+    loaded.last_readiness_status = ReadinessState.NOT_READY
+    loaded.last_readiness_reasons = ["synthetic failure"]
+    in_memory_uow.changes.save(loaded)
+
+    saved = in_memory_uow.changes.get_by_id(first.change_id)
+    assert saved.status == ChangeStatus.DISCOVERED
+    assert saved.last_readiness_status == ReadinessState.NOT_READY
+    assert saved.last_readiness_reasons == ["synthetic failure"]
+
+
+def test_in_memory_get_by_name_fails_closed_on_corruption(in_memory_uow):
+    first = make_change(change_id="one")
+    second = make_change(change_id="two")
+    in_memory_uow.changes._store[first.change_id] = first
+    in_memory_uow.changes._store[second.change_id] = second
+
+    with pytest.raises(ValueError, match="Ambiguous logical Change identity"):
+        in_memory_uow.changes.get_by_name("mini-me", "010-logical-identity")
+
+
+def test_postgres_repository_logical_upsert_and_ambiguity():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(
+            ProjectModel(
+                id="mini-me",
+                display_name="Mini Me",
+                repository="silverberdi/mini-me",
+                checks=[],
+                external_providers_allowed=[],
+                deployment_preview={},
+                deployment_production={},
+                status=ProjectStatus.ACTIVE.value,
+            )
+        )
+        session.commit()
+        repo = PostgresChangeRepository(session)
+        assert repo.get_by_name("mini-me", "missing") is None
+        first = make_change(
+            change_id="stable-id",
+            status=ChangeStatus.READY,
+            last_readiness_status=ReadinessState.READY,
+            proposal_path="old/proposal.md",
+        )
+        repo.save(first)
+        session.commit()
+        repo.save(make_change(change_id="new-id", proposal_path="new/proposal.md"))
+        session.commit()
+
+        saved = repo.get_by_name("mini-me", "010-logical-identity")
+        assert saved is not None
+        assert saved.change_id == "stable-id"
+        assert saved.discovered_at.replace(tzinfo=UTC) == first.discovered_at
+        assert saved.proposal_path == "new/proposal.md"
+        assert saved.status == ChangeStatus.READY
+        loaded = repo.get_by_name("mini-me", "010-logical-identity")
+        loaded.status = ChangeStatus.DISCOVERED
+        loaded.last_readiness_status = ReadinessState.NOT_READY
+        loaded.last_readiness_reasons = ["synthetic failure"]
+        repo.save(loaded)
+        session.commit()
+        regressed = repo.get_by_name("mini-me", "010-logical-identity")
+        assert regressed.status == ChangeStatus.DISCOVERED
+        assert regressed.last_readiness_status == ReadinessState.NOT_READY
+        assert regressed.last_readiness_reasons == ["synthetic failure"]
+        assert session.scalar(
+            select(func.count()).select_from(ChangeModel).where(ChangeModel.project_id == "mini-me")
+        ) == 1
+
+def test_change_model_declares_stable_unique_constraint():
+    constraint = next(
+        c for c in ChangeModel.__table__.constraints if c.name == "uq_changes_project_name"
+    )
+    assert [column.name for column in constraint.columns] == ["project_id", "name"]


### PR DESCRIPTION
## Summary

Fixes non-deterministic persisted OpenSpec Change identity discovered during the 010 bootstrap preflight.

### Changes

- enforces `UNIQUE(project_id, name)` for persisted Changes
- makes rediscovery idempotent by logical identity
- preserves durable Change ID and original discovery timestamp
- distinguishes rediscovery from explicit lifecycle/readiness updates
- fails closed on ambiguous logical identities
- reconciles historical duplicate Change rows deterministically
- adds Alembic revision `008b_change_identity`
- adds regression and migration coverage

### Migration

`008b_change_identity`
down revision: `008_autonomous_orchestration`

The migration preserves the earliest physical Change row, transfers the authoritative valid state, removes redundant duplicate rows, then creates `uq_changes_project_name`.

### Verification

- complementary review: `READY_TO_FREEZE`
- focused tests: 7 passed
- full safe suite: 322 passed, 5 skipped
- Ruff: PASS
- `git diff --check`: PASS
- Alembic: single head `008b_change_identity`
- disposable PostgreSQL migration acceptance: PASS
- OpenSpec 010 untouched
- canonical `minime` database not migrated during implementation/review

Human merge required.