### PR TITLE
fix: execute all authoritative checks

### DIFF
--- a/src/minime/services/checks_runner.py
+++ b/src/minime/services/checks_runner.py
@@ -59,7 +59,7 @@ class ChecksRunner:
                     evidence_reference={"exit_code": 2},
                 )
                 diagnostics.append(diag)
-                return ChecksRunResult(passed=False, results=results, diagnostics=diagnostics)
+                continue
 
             start = asyncio.get_running_loop().time()
             try:
@@ -117,7 +117,8 @@ class ChecksRunner:
             )
             diagnostics.append(diag)
 
-            if result.exit_code != 0:
-                return ChecksRunResult(passed=False, results=results, diagnostics=diagnostics)
-
-        return ChecksRunResult(passed=True, results=results, diagnostics=diagnostics)
+        return ChecksRunResult(
+            passed=all(result.exit_code == 0 for result in results),
+            results=results,
+            diagnostics=diagnostics,
+        )

--- a/tests/test_candidate_manifest_and_diagnostics.py
+++ b/tests/test_candidate_manifest_and_diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -282,3 +283,69 @@ async def test_checks_runner_diagnostics_classification(tmp_path: Path):
     assert (
         res_env.diagnostics[0].diagnostic_status == EvidenceDiagnosticStatus.ENVIRONMENT_UNAVAILABLE
     )
+
+
+@pytest.mark.asyncio
+async def test_checks_runner_continues_after_failed_check_in_configured_order(tmp_path: Path):
+    runner = ChecksRunner()
+    result = await runner.run(
+        job_id="job-order",
+        checks=[
+            {"name": "first", "command": f"{sys.executable} -c 'exit(3)'"},
+            {"name": "second", "command": f"{sys.executable} -c 'print(\"ran\")'"},
+        ],
+        worktree_path=tmp_path,
+    )
+
+    assert [item.check_name for item in result.results] == ["first", "second"]
+    assert [item.check_name for item in result.diagnostics] == ["first", "second"]
+    assert result.results[1].output_snippet == "ran\n"
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_checks_runner_missing_command_does_not_block_later_check(tmp_path: Path):
+    runner = ChecksRunner()
+    result = await runner.run(
+        job_id="job-missing",
+        checks=[
+            {"name": "missing"},
+            {"name": "valid", "command": f"{sys.executable} -c 'print(\"valid\")'"},
+        ],
+        worktree_path=tmp_path,
+    )
+
+    assert [item.check_name for item in result.results] == ["missing", "valid"]
+    assert [item.check_name for item in result.diagnostics] == ["missing", "valid"]
+    assert result.diagnostics[0].diagnostic_status == EvidenceDiagnosticStatus.FAIL
+    assert result.diagnostics[1].diagnostic_status == EvidenceDiagnosticStatus.PASS
+
+
+@pytest.mark.asyncio
+async def test_checks_runner_aggregate_passed_is_false_when_any_check_fails(tmp_path: Path):
+    result = await ChecksRunner().run(
+        job_id="job-aggregate-fail",
+        checks=[
+            {"name": "pass", "command": f"{sys.executable} -c 'exit(0)'"},
+            {"name": "fail", "command": f"{sys.executable} -c 'exit(1)'"},
+        ],
+        worktree_path=tmp_path,
+    )
+
+    assert result.passed is False
+    assert len(result.results) == len(result.diagnostics) == 2
+
+
+@pytest.mark.asyncio
+async def test_checks_runner_aggregate_passed_is_true_when_all_checks_pass(tmp_path: Path):
+    result = await ChecksRunner().run(
+        job_id="job-aggregate-pass",
+        checks=[
+            {"name": "first", "command": f"{sys.executable} -c 'exit(0)'"},
+            {"name": "second", "command": f"{sys.executable} -c 'exit(0)'"},
+        ],
+        worktree_path=tmp_path,
+    )
+
+    assert result.passed is True
+    assert len(result.results) == len(result.diagnostics) == 2

--- a/tests/test_execution_pipeline.py
+++ b/tests/test_execution_pipeline.py
@@ -331,7 +331,7 @@ async def test_execution_pipeline_check_failure_halts_and_records_result(in_memo
 
     assert job.status == JobStatus.CHECKS_FAILED
     checks = in_memory_uow.check_results.list_by_job(job.job_id)
-    assert [c.check_name for c in checks] == ["fail"]
+    assert [c.check_name for c in checks] == ["fail", "skip"]
     assert checks[0].exit_code == 4
 
 

--- a/tests/test_postgres_state.py
+++ b/tests/test_postgres_state.py
@@ -1,6 +1,7 @@
 """Tests for PostgreSQL durable state, Alembic migrations, and persistence primitives."""
 
 import subprocess
+import sys
 
 from minime.db.models import (
     Base,
@@ -39,7 +40,7 @@ def test_models_metadata_tables():
 def test_alembic_offline_postgres_migration():
     """Verify that Alembic generates PostgreSQL-compatible DDL without error."""
     result = subprocess.run(
-        [".venv/bin/alembic", "upgrade", "head", "--sql"],
+        [sys.executable, "-m", "alembic", "upgrade", "head", "--sql"],
         env={"MINIME_DATABASE_URL": "postgresql://minime:pass@localhost:5432/minime"},
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

Bootstrap hotfix #7 fixes authoritative deterministic-check execution and managed-worktree test portability.

## Defects fixed

- `ChecksRunner` previously stopped after the first failed check.
- This could leave configured checks without persisted evidence and cause orchestration to stop with `INCOMPLETE_AUTHORITATIVE_CHECKS`.
- The Alembic offline PostgreSQL test invoked `.venv/bin/alembic`, which does not exist inside managed worktrees.

## Resulting invariants

- Every configured deterministic check runs sequentially.
- Every configured check produces a `CheckResult` and diagnostic.
- A failed or missing-command check does not prevent later configured checks from executing.
- Aggregate check status passes only when all configured checks pass.
- Orchestration remains fail-closed.
- Alembic offline migration verification uses the currently running Python interpreter and is portable to managed worktrees.
- No `.venv` is copied or linked into candidate worktrees.

## Verification

- Focused tests: 14 passed
- Full safe suite: 346 passed, 8 skipped
- Ruff: PASS
- git diff --check: PASS
- Alembic head: 008b_change_identity
- OpenSpec 010 untouched
- No schema migration added

## Scope

Bootstrap runtime integrity hotfix only.

This PR does not implement OpenSpec 010.