### PR TITLE
Hotfix — scope legacy candidate adoption to historical generation

### DIFF
--- a/src/minime/services/orchestration_service.py
+++ b/src/minime/services/orchestration_service.py
@@ -397,15 +397,27 @@ class OrchestrationService:
         ]
         if candidate is not None and record_adoption_events:
             evidence = record_adoption_events[-1].evidence_references
+            historical_candidate = next(
+                (
+                    existing
+                    for existing in self.uow.orchestration_candidates.list_by_run(run_id)
+                    if existing.candidate_id == evidence.get("candidate_id")
+                ),
+                None,
+            )
+            if historical_candidate is None:
+                raise ValueError(
+                    "Legacy candidate record adoption references a missing candidate record."
+                )
             if any(
                 evidence.get(field) != value
                 for field, value in {
-                    "candidate_id": candidate.candidate_id,
-                    "candidate_generation": candidate.generation,
-                    "candidate_sha": candidate.candidate_sha,
-                    "base_sha": candidate.base_sha,
-                    "manifest_id": candidate.manifest_id,
-                    "manifest_hash": candidate.manifest_hash,
+                    "candidate_id": historical_candidate.candidate_id,
+                    "candidate_generation": historical_candidate.generation,
+                    "candidate_sha": historical_candidate.candidate_sha,
+                    "base_sha": historical_candidate.base_sha,
+                    "manifest_id": historical_candidate.manifest_id,
+                    "manifest_hash": historical_candidate.manifest_hash,
                 }.items()
             ):
                 raise ValueError(

--- a/tests/test_legacy_preserved_candidate_adoption.py
+++ b/tests/test_legacy_preserved_candidate_adoption.py
@@ -6,7 +6,7 @@ import pytest
 from tests.test_human_resolution_real_git import git, make_repo, make_service
 
 from minime.domain.enums import EventType, OrchestrationStage
-from minime.domain.models import CandidateManifest, OrchestrationStageEvent
+from minime.domain.models import CandidateManifest, OrchestrationCandidate, OrchestrationStageEvent
 
 
 def legacy_service(in_memory_uow, repo, base_a, candidate_sha):
@@ -39,6 +39,109 @@ def prepare_legacy_branch(repo, candidate_sha, job_id="job-human-resolution"):
     )
     git(repo, "branch", ref.removeprefix("refs/heads/"), candidate_sha)
     return ref
+
+
+def two_generation_legacy_service(in_memory_uow, repo, base_a, candidate_sha, base_b, *, bad_sha=None):
+    service, run_id = legacy_service(in_memory_uow, repo, base_a, candidate_sha)
+    project = in_memory_uow.projects.get_by_id("mini-me")
+    project.checks = []
+    in_memory_uow.projects.save(project)
+    historical_manifest = in_memory_uow.candidate_manifests.get_by_candidate_sha(
+        "job-human-resolution", candidate_sha
+    )
+    historical = OrchestrationCandidate(
+        run_id=run_id,
+        generation=1,
+        base_sha=base_a,
+        candidate_sha=candidate_sha,
+        candidate_ref="refs/heads/historical-candidate",
+        manifest_id=historical_manifest.manifest_id,
+        manifest_hash=historical_manifest.manifest_hash,
+        is_frozen=True,
+    )
+    git(repo, "branch", "current-candidate", base_b)
+    current_sha = git(repo, "rev-parse", "refs/heads/current-candidate")
+    current = OrchestrationCandidate(
+        run_id=run_id,
+        generation=2,
+        base_sha=base_b,
+        candidate_sha=current_sha,
+        candidate_ref="refs/heads/current-candidate",
+        manifest_id="current-manifest",
+        manifest_hash="current-manifest-hash",
+        is_frozen=True,
+    )
+    in_memory_uow.orchestration_candidates.save(historical)
+    in_memory_uow.orchestration_candidates.save(current)
+    in_memory_uow.orchestration_candidates.supersede(
+        historical.candidate_id, current.candidate_id
+    )
+    run = in_memory_uow.orchestration_runs.get_by_id(run_id)
+    run.base_sha = base_b
+    run.current_generation = 2
+    run.current_candidate_sha = current_sha
+    in_memory_uow.orchestration_runs.save(run)
+    job = in_memory_uow.jobs.get_by_id("job-human-resolution")
+    job.base_sha = base_b
+    job.candidate_sha = current_sha
+    in_memory_uow.jobs.save(job)
+    evidence = {
+        "run_id": run_id,
+        "job_id": job.job_id,
+        "candidate_id": historical.candidate_id,
+        "candidate_generation": historical.generation,
+        "candidate_sha": bad_sha or historical.candidate_sha,
+        "base_sha": historical.base_sha,
+        "manifest_id": historical.manifest_id,
+        "manifest_hash": historical.manifest_hash,
+    }
+    in_memory_uow.orchestration_stage_events.save(
+        OrchestrationStageEvent(
+            run_id=run_id,
+            from_stage=OrchestrationStage.COMPLEMENTARY_REVIEW,
+            to_stage=OrchestrationStage.COMPLEMENTARY_REVIEW,
+            event_type=EventType.LEGACY_CANDIDATE_RECORD_ADOPTED.value,
+            transition_key=f"historical-adoption-{historical.candidate_id}",
+            evidence_references=evidence,
+        )
+    )
+    return service, run_id, historical, current
+
+
+def test_historical_record_adoption_remains_valid_after_current_generation_advances(
+    tmp_path, in_memory_uow
+):
+    repo, base_a, candidate_sha, base_b = make_repo(tmp_path, conflict=False)
+    service, run_id, historical, current = two_generation_legacy_service(
+        in_memory_uow, repo, base_a, candidate_sha, base_b
+    )
+    service.drive_coordinator = lambda run_id, project_root=None: (
+        in_memory_uow.orchestration_runs.get_by_id(run_id)
+    )
+
+    resolved = service.resolve_preserved_candidate(
+        run_id, continue_preserved_candidate=True, project_root=repo
+    )
+
+    assert resolved.current_generation == 2
+    assert historical.candidate_id != current.candidate_id
+    assert in_memory_uow.orchestration_candidates.get_by_id(
+        historical.candidate_id
+    ).superseded_by_id == current.candidate_id
+
+
+def test_historical_record_adoption_rejects_contradictory_historical_sha(
+    tmp_path, in_memory_uow
+):
+    repo, base_a, candidate_sha, base_b = make_repo(tmp_path, conflict=False)
+    service, run_id, _, _ = two_generation_legacy_service(
+        in_memory_uow, repo, base_a, candidate_sha, base_b, bad_sha=git(repo, "rev-parse", "main")
+    )
+
+    with pytest.raises(ValueError, match="conflicts with the candidate record"):
+        service.resolve_preserved_candidate(
+            run_id, continue_preserved_candidate=True, project_root=repo
+        )
 
 
 def test_legacy_ref_adoption_validates_real_git_and_continues_resolution(


### PR DESCRIPTION
Fixes preserved-candidate resolution when a valid historical LEGACY_CANDIDATE_RECORD_ADOPTED event belongs to a superseded generation.

Root cause:
Historical adoption evidence was incorrectly compared against the latest candidate.

Correction:
The event is now validated against the exact historical candidate referenced by candidate_id within the same run.

Verification:
- focused tests: 53 passed
- full safe pytest: 392 passed, 8 skipped
- Ruff: PASS
- git diff --check: PASS
- OpenSpec: 33 passed, 0 failed
- Alembic: 010_candidate_remediation (head)
- canonical PostgreSQL untouched

This is a narrow bootstrap hotfix. Human merge required.