### PR TITLE
Hotfix — retry candidate integration after base advance

### DIFF
--- a/src/minime/services/orchestration_service.py
+++ b/src/minime/services/orchestration_service.py
@@ -52,6 +52,7 @@ from minime.services.candidate_remediation import CandidateRemediationService
 from minime.services.execution_pipeline import ExecutionPipelineService
 from minime.services.project_service import ProjectService
 from minime.services.readiness_service import ReadinessService
+from minime.services.worktree_manager import WorktreeInfo
 
 logger = logging.getLogger(__name__)
 ORCHESTRATION_TRANSITION_KEY_MAX_LENGTH = 128
@@ -682,9 +683,16 @@ class OrchestrationService:
             )
             if existing:
                 return self.uow.orchestration_runs.get_by_id(run_id) or run
-            branch_name = f"minime/{run.change_name}-{job.job_id}-integration-gen{next_generation}"
+            target_short_sha = current_base[:12]
+            branch_name = (
+                f"minime/{run.change_name}-{job.job_id}-integration-gen{next_generation}-"
+                f"{target_short_sha}"
+            )
             integration_path = (
-                root / ".minime" / "worktrees" / f"{job.job_id}-integration-gen{next_generation}"
+                root
+                / ".minime"
+                / "worktrees"
+                / f"{job.job_id}-integration-gen{next_generation}-{target_short_sha}"
             )
             manager = self.pipeline.worktree_manager
             try:
@@ -729,8 +737,13 @@ class OrchestrationService:
                     if already_on_base.returncode != 0:
                         commits.append(commit_sha)
                 worktree = asyncio.run(
-                    manager.create_integration_worktree(
-                        job.job_id, branch_name, current_base, next_generation, run.project_id
+                    self._create_targeted_integration_worktree(
+                        manager,
+                        integration_path,
+                        branch_name,
+                        current_base,
+                        job,
+                        run,
                     )
                 )
                 integrated_sha = asyncio.run(
@@ -974,24 +987,38 @@ class OrchestrationService:
             and event.evidence_references.get("target_base_sha")
             and event.evidence_references.get("integration_branch")
         ]
-        if len(matching_conflicts) != 1:
-            raise ValueError("Stopped integration evidence does not identify exactly one source attempt.")
-        conflict = matching_conflicts[0]
-        details = conflict.evidence_references
-        target_base = str(details["target_base_sha"])
         current_base, base_error = resolve_base_branch_sha(root, project.base_branch)
         if not current_base:
             raise ValueError(base_error or "Current registered base could not be resolved.")
-        if current_base != target_base:
-            raise ValueError("Registered base no longer matches the original integration target.")
+        current_target_conflicts = [
+            event
+            for event in matching_conflicts
+            if event.evidence_references.get("target_base_sha") == current_base
+        ]
+        if not current_target_conflicts:
+            # Prior failures are historical for the newly registered base; the
+            # caller will start a distinct integration attempt below.
+            return None
+        if len(current_target_conflicts) != 1:
+            raise ValueError("Current integration evidence identifies multiple source attempts.")
+        conflict = current_target_conflicts[0]
+        details = conflict.evidence_references
+        target_base = str(details["target_base_sha"])
 
         next_generation = source.generation + 1
-        branch_name = f"minime/{run.change_name}-{job.job_id}-integration-gen{next_generation}"
+        target_short_sha = target_base[:12]
+        branch_name = (
+            f"minime/{run.change_name}-{job.job_id}-integration-gen{next_generation}-"
+            f"{target_short_sha}"
+        )
         expected_ref = f"refs/heads/{branch_name}"
         if details["integration_branch"] != branch_name:
             raise ValueError("Human integration branch is not the deterministic expected branch.")
         integration_path = (
-            root / ".minime" / "worktrees" / f"{job.job_id}-integration-gen{next_generation}"
+            root
+            / ".minime"
+            / "worktrees"
+            / f"{job.job_id}-integration-gen{next_generation}-{target_short_sha}"
         ).resolve()
         recorded_path = details.get("worktree_path")
         if recorded_path and Path(recorded_path).resolve() != integration_path:
@@ -1159,6 +1186,32 @@ class OrchestrationService:
         )
         self.uow.commit()
         return new_candidate
+
+    @staticmethod
+    async def _create_targeted_integration_worktree(
+        manager: Any,
+        path: Path,
+        branch_name: str,
+        base_sha: str,
+        job: Job,
+        run: OrchestrationRun,
+    ) -> WorktreeInfo:
+        """Create a managed integration worktree whose identity includes its target base."""
+        if path.exists():
+            state = await manager.inspect_worktree_state(path)
+            if state.dirty:
+                raise RuntimeError(f"Existing integration worktree is dirty: {path}")
+            return WorktreeInfo(path, branch_name, base_sha)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        await manager._git(
+            ["worktree", "add", "-b", branch_name, str(path), base_sha],
+            cwd=manager.project_root,
+            job_id=job.job_id,
+            project_id=run.project_id,
+            operation_type="candidate_base_integration_worktree_add",
+            managed_worktree_path=path,
+        )
+        return WorktreeInfo(path, branch_name, base_sha)
 
     def _find_transition_event(
         self,

--- a/tests/test_human_resolution_real_git.py
+++ b/tests/test_human_resolution_real_git.py
@@ -181,12 +181,12 @@ def test_advanced_base_real_git_conflict_preserves_integration_state(
     assert len(in_memory_uow.orchestration_candidates.list_by_run(run_id)) == 1
     assert git(repo, "rev-parse", "refs/heads/historical-candidate") == candidate_sha
 
-    integration_path = (
-        repo / ".minime" / "worktrees" / "job-human-resolution-integration-gen2"
+    integration_path = repo / ".minime" / "worktrees" / (
+        f"job-human-resolution-integration-gen2-{base_b[:12]}"
     )
     integration_branch = (
         "refs/heads/minime/010-governance-and-recovery-hardening-"
-        "job-human-resolution-integration-gen2"
+        f"job-human-resolution-integration-gen2-{base_b[:12]}"
     )
     assert integration_path.exists()
     assert git(repo, "show-ref", "--verify", integration_branch)
@@ -227,7 +227,9 @@ def test_completed_human_integration_is_reconciled_idempotently(tmp_path, in_mem
     service.resolve_preserved_candidate(
         run_id, continue_preserved_candidate=True, project_root=repo
     )
-    integration_path = repo / ".minime" / "worktrees" / "job-human-resolution-integration-gen2"
+    integration_path = repo / ".minime" / "worktrees" / (
+        f"job-human-resolution-integration-gen2-{base_b[:12]}"
+    )
     (integration_path / "shared.txt").write_text("candidate\n", encoding="utf-8")
     git(integration_path, "add", "shared.txt")
     git(integration_path, "-c", "core.editor=true", "cherry-pick", "--continue")
@@ -255,3 +257,57 @@ def test_completed_human_integration_is_reconciled_idempotently(tmp_path, in_mem
         and event.evidence_references.get("resulting_candidate_sha")
     ]
     assert len(resolutions) == 1
+
+
+def test_stale_integration_target_retries_with_distinct_target_identity(
+    tmp_path, in_memory_uow
+):
+    repo, base_a, candidate_sha, base_b = make_repo(tmp_path, conflict=True)
+    service, run_id = make_service(
+        in_memory_uow, repo, base_a, candidate_sha, "refs/heads/historical-candidate"
+    )
+    service.resolve_preserved_candidate(
+        run_id, continue_preserved_candidate=True, project_root=repo
+    )
+    old_event = next(
+        event
+        for event in in_memory_uow.orchestration_stage_events.list_by_run(run_id)
+        if event.evidence_references.get("code") == "BASE_INTEGRATION_CONFLICT"
+    )
+
+    (repo / "later.txt").write_text("later base\n", encoding="utf-8")
+    git(repo, "add", "later.txt")
+    git(repo, "commit", "-m", "base C")
+    base_c = git(repo, "rev-parse", "HEAD")
+    git(repo, "update-ref", "refs/remotes/origin/main", base_c)
+
+    resolved = service.resolve_preserved_candidate(
+        run_id, continue_preserved_candidate=True, project_root=repo
+    )
+    assert resolved.stop_outcome == OrchestrationStopOutcome.NEEDS_HUMAN
+    assert len(in_memory_uow.orchestration_candidates.list_by_run(run_id)) == 1
+    events = [
+        event
+        for event in in_memory_uow.orchestration_stage_events.list_by_run(run_id)
+        if event.evidence_references.get("code") == "BASE_INTEGRATION_CONFLICT"
+    ]
+    assert len(events) == 2
+    assert old_event.evidence_references["target_base_sha"] == base_b
+    assert old_event.evidence_references["integration_branch"].endswith(base_b[:12])
+    assert events[-1].evidence_references["target_base_sha"] == base_c
+    assert events[-1].evidence_references["integration_branch"].endswith(base_c[:12])
+    assert events[-1].evidence_references["integration_branch"] != old_event.evidence_references[
+        "integration_branch"
+    ]
+
+    with pytest.raises(ValueError, match="Human integration"):
+        service.resolve_preserved_candidate(
+            run_id, continue_preserved_candidate=True, project_root=repo
+        )
+    assert len(
+        [
+            event
+            for event in in_memory_uow.orchestration_stage_events.list_by_run(run_id)
+            if event.evidence_references.get("code") == "BASE_INTEGRATION_CONFLICT"
+        ]
+    ) == 2


### PR DESCRIPTION
Makes preserved-candidate base integration converge when main advances after a failed human-resolution attempt.

Key behavior:
- stale integration targets remain immutable history
- retries use the current authoritative base
- branch/worktree identity includes target base
- same-base retries are idempotent
- generation N+1 is persisted only after successful integration

Verification:
- focused real-Git suite: 4 passed
- full safe pytest: 394 passed, 8 skipped
- Ruff: PASS
- git diff --check: PASS
- OpenSpec: 33 passed, 0 failed
- Alembic: 010_candidate_remediation (head)
- canonical PostgreSQL untouched
- real orchestration run untouched

Human merge required.