### PR TITLE
feat: add governed local worker bootstrap

### DIFF
--- a/openspec/changes/minimal-local-worker-bootstrap/design.md
+++ b/openspec/changes/minimal-local-worker-bootstrap/design.md
@@ -1,0 +1,79 @@
+# Design: Minimal Local Worker Bootstrap
+
+## Architectural Approach
+A bounded, purely additive capability that reuses existing provider/model abstractions and
+keeps all execution determinism and authority in mini me core:
+
+```
+LocalTaskEnvelope ──> Eligibility Gate (allowed class + forbidden surfaces)
+       |   (admitted / refused)
+       v
+LocalWorkerService:
+  1. preflight  -> Ollama reachable + model qwen2.5-coder:7b-instruct-q4_K_M exists
+  2. harness    -> bounded timeout/cancel + one corrective attempt
+  3. structured output validation (Qwen never self-approves)
+  4. evidence   -> provider/model/task_class/attempt/result/validation_result/escalation
+  5. escalation -> existing provider policy when refused/unvalidated/uncertain/risk
+```
+
+The core makes the local verdict; Qwen only produces a constrained candidate result. This
+preserves the rule that deterministic validation (scope/diff guard, ruff, targeted tests,
+OpenSpec validation) remains authoritative and that a single provider/model identity never
+self-reviews.
+
+## Key Components
+
+### 1. `local_worker/model_identity.py`
+- `OLLAMA_PROVIDER` = `"ollama"`.
+- `LOCAL_WORKER_ROLE` = `"local_worker"` (never reviewer/auditor/merge/approve).
+- `STDLOCAL_QWEN_MODEL_IDENTITY` = `"qwen2.5-coder:7b-instruct-q4_K_M"` — exact canonical
+  identity comparison helper.
+
+### 2. `local_worker/task_classes.py`
+- Canonical allowlist (`SMALL_CODE_FIX`, `TEST_AUTHORING`, `LOG_ANALYSIS`,
+  `SMALL_REFACTOR`, `API_SMALL_CHANGE`, `UI_SMALL_POLISH`).
+- Forbidden-surface matchers for lifecycle/state-machine, provider-policy,
+  security-sensitive, database schema/migrations, architecture, deployment/runtime
+  infrastructure, destructive operations, and uncertain classification.
+
+### 3. `local_worker/models.py` (Pydantic v2)
+Deterministic task envelope, structured result (with `NO_CHANGE_JUSTIFIED` as a valid
+outcome), eligibility/escalation decisions, preflight and validation result records, and a
+flat execution-evidence record that captures provider, model, task class, attempt, result,
+validation result and escalation.
+
+### 4. `local_worker/ollama_adapter.py`
+Thin HTTP adapter. Accepts an injected `httpx.AsyncClient`/transport so all tests run
+offline (MockTransport). Reachability (`/api/tags`) and model existence (`/api/show` name
+match) preflight; bounded generate; maps outcomes to `ProviderResultClass` so existing
+provider-policy taxonomy is reused.
+
+### 5. `local_worker/policy.py`
+- `evaluate_eligibility`: LOW-risk admission gate. Admit only an allowlisted task class with
+  no forbidden surfaces and only allowed files. Refuse/escalate otherwise with a
+  deterministic `EligibilityDecision`.
+- `local_worker_authorities`: enforced set proving no review/audit/merge/approve authority.
+- `escalate`: clean handoff decision surfaced in evidence for the existing provider policy.
+
+### 6. `local_worker/harness.py`
+- Bounded `asyncio.wait_for` around each dispatch for timeout/cancellation semantics.
+- Terminates/cancels in-flight work and performs cleanup when a deadline fires.
+- Caps corrective attempts at 1; when the first validated result fails deterministic
+  validation, performs exactly one bounded corrective attempt, then stops.
+
+### 7. `local_worker/service.py`
+`LocalWorkerService` orchestrates preflight -> eligibility -> dispatch -> validation ->
+evidence, and never requires a live Ollama at import/collection time.
+
+## Invariants
+- Deterministic validation is authoritative; Qwen cannot approve its own result.
+- Local Qwen has NO review/audit/merge/approve authority.
+- Max one local corrective attempt; no unbounded retry.
+- No public surface marks the local model as a reviewer or auditor.
+- Clean escalation to existing provider policy is always available via a recorded decision.
+- Tests require no live Ollama (injected transport).
+
+## Rollback / Operational Notes
+This change is additive and configuration-only; it does not touch scheduler, DB or
+deployment runtime. It can be reverted by removing the `local_worker` package, the config
+example entry and the OpenSpec change folder.

--- a/openspec/changes/minimal-local-worker-bootstrap/proposal.md
+++ b/openspec/changes/minimal-local-worker-bootstrap/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: Minimal Local Worker Bootstrap
+
+## Problem Statement
+mini me currently routes all substantive implementation to remote CLI/HTTP providers
+(Codex / Antigravity / OpenRouter drain / DeepSeek audit). Routine, bounded, LOW-risk
+mechanical coding work (small code fixes, test authoring, log analysis, small refactors,
+small API changes, small UI polish) otherwise consumes scarce frontier quota and network
+dependencies even though a local model would be sufficient to produce the work.
+
+mini me already treats Qwen as advisory only. There is no canonical, deterministic,
+bounded path for a local worker to execute a constrained LOW-risk coding task through
+local Ollama and feed that work into the existing deterministic validation + escalation
+seams. Building that path opportunistically (full scheduler/provider-policy redesign,
+capability registries, telemetry, routing, benchmarking) is explicitly out of scope and
+belongs to the future Adaptive AI Execution backlog program.
+
+## Proposed Change
+Introduce the **smallest canonical capability** required to execute bounded LOW-risk work
+through local Ollama using exactly the model `qwen2.5-coder:7b-instruct-q4_K_M`:
+
+1. A minimal generic local/Ollama provider adapter.
+2. Exact model identity persisted/represented: `qwen2.5-coder:7b-instruct-q4_K_M`.
+3. Deterministic preflight: Ollama reachable, required model present, execution readiness.
+4. Bounded timeout / cancellation / process cleanup.
+5. A constrained execution harness with explicitly scoped task envelopes.
+6. LOW-risk task eligibility with a canonical allowlist of task classes:
+   `SMALL_CODE_FIX`, `TEST_AUTHORING`, `LOG_ANALYSIS`, `SMALL_REFACTOR`,
+   `API_SMALL_CHANGE`, `UI_SMALL_POLISH`.
+7. Explicit forbidden/high-risk task classes and forbidden surfaces.
+8. At most one local corrective attempt (no unbounded retry loop).
+9. Deterministic validation remains authoritative: the local model never decides that its
+   own work is successful.
+10. Clean escalation to the existing provider policy when the local worker is not
+    admissible/authoritative.
+11. Minimal, structured execution evidence:
+    provider, model, task class, attempt, result, validation result, escalation.
+12. Local Qwen carries no merge/review/audit authority.
+
+## Acceptance Criteria
+1. Canonical model identity is stored exactly as `qwen2.5-coder:7b-instruct-q4_K_M`.
+2. Deterministic tests prove the tests release does not require a live Ollama.
+3. Unavailable Ollama fails preflight with a deterministic reason.
+4. Missing required model fails preflight with a deterministic reason.
+5. Allowed LOW-risk task class (e.g. `SMALL_CODE_FIX`) is admitted by the eligibility gate.
+6. Any forbidden/high-risk class/surface is deterministically refused/escalated.
+7. Structured output validation is enforced; `NO_CHANGE_JUSTIFIED` is a valid, accepted result.
+8. Execution is bounded by a timeout; cancellation cleans up underlying work when present.
+9. The corrective loop is capped at exactly one local corrective attempt.
+10. Escalation to existing provider policy is clean and recorded in evidence.
+11. Local Qwen has no reviewer/auditor/merge/approve authority anywhere.
+
+## Non-Goals (future Adaptive AI Execution backlog program)
+These are explicitly NOT implemented here and must not be built opportunistically:
+- `ai-provider-model-capability-registry`
+- `execution-attempt-effectiveness-telemetry`
+- `task-complexity-risk-classification`
+- `shared-skill-execution-harness-framework`
+- `ollama-qwen-local-worker-integration`
+- `adaptive-provider-model-routing`
+- AI Operations dashboard, benchmarking/calibration, Cursor integration,
+  OpenRouter policy redesign.
+
+No scheduler wiring, no orchestration core changes, no database schema/migration changes are
+introduced by this bootstrap. Scheduler restart is not required.

--- a/openspec/changes/minimal-local-worker-bootstrap/specs/minimal-local-worker-bootstrap/spec.md
+++ b/openspec/changes/minimal-local-worker-bootstrap/specs/minimal-local-worker-bootstrap/spec.md
@@ -1,0 +1,103 @@
+# Spec: Minimal Local Worker Bootstrap
+
+## ADDED Requirements
+
+### Requirement: Minimal local worker bootstrap
+
+The local worker SHALL execute only bounded LOW-risk tasks through the canonical Ollama
+provider/model identity, subject to deterministic eligibility, validation, bounded retry,
+escalation, and evidence rules below.
+
+#### Scenario: Exact model identity is canonical
+
+GIVEN the canonical local worker model identity
+WHEN it is compared for exactness
+THEN it SHALL equal the exact string `qwen2.5-coder:7b-instruct-q4_K_M`
+AND this exact value SHALL be the single persisted/represented model identity used by the
+local worker harness.
+
+#### Scenario: Live Ollama is not required by tests
+
+GIVEN the automated test suite for local worker bootstrap
+WHEN it is collected and executed
+THEN it SHALL NOT require a reachable Ollama daemon or a local model download.
+
+#### Scenario: Unavailable Ollama fails preflight
+
+GIVEN an environment where Ollama is not reachable
+WHEN local worker preflight is evaluated
+THEN preflight SHALL fail with a deterministically structured reason.
+
+#### Scenario: Missing required model fails preflight
+
+GIVEN Ollama is reachable but the canonical model `qwen2.5-coder:7b-instruct-q4_K_M` is not
+available
+WHEN local worker preflight is evaluated
+THEN preflight SHALL fail with a structured reason identifying the missing model.
+
+#### Scenario: Allowed LOW-risk task class is accepted
+
+GIVEN a task envelope whose `task_class` is a member of
+`SMALL_CODE_FIX | TEST_AUTHORING | LOG_ANALYSIS | SMALL_REFACTOR | API_SMALL_CHANGE |
+UI_SMALL_POLISH`
+AND whose allowed files/forbidden surfaces are consistent
+WHEN the eligibility gate evaluates it
+THEN it SHALL be admitted (not refused, not escalated).
+
+#### Scenario: Forbidden / high-risk task class is rejected
+
+GIVEN a task that touches lifecycle/state-machine, provider policy, security-sensitive
+surfaces, database schema/migrations, architecture, deployment/runtime infrastructure,
+destructive operations, or bears uncertain classification
+WHEN the eligibility gate evaluates it
+THEN it SHALL be deterministically refused with a structured reason AND routed to clean
+escalation; the local worker SHALL NOT execute it.
+
+#### Scenario: Structured output validation
+
+GIVEN a structured local worker result
+WHEN it is validated
+THEN it SHALL only be accepted when it parses to the constrained schema
+AND `NO_CHANGE_JUSTIFIED` SHALL be a valid, accepted outcome of the harness.
+
+#### Scenario: Bounded timeout / failure
+
+GIVEN a dispatched local worker task that exceeds its deadline
+WHEN the deadline fires
+THEN execution SHALL be cancelled, in-flight work cleaned up, and the harness SHALL record a
+timeout result without spawning unlimited work.
+
+#### Scenario: No unbounded retry; one corrective attempt
+
+GIVEN the first structured result fails deterministic validation
+WHEN a corrective pass is considered
+THEN harness SHALL allow at most one local corrective attempt
+AND if that corrective attempt still fails validation it SHALL stop and record escalation.
+
+#### Scenario: Deterministic validation is authoritative / no self-approval
+
+GIVEN a local Qwen candidate result
+WHEN it is evaluated for success
+THEN success SHALL be decided only by mini me deterministic validation
+AND the local model (and its own result) SHALL NOT grant approval by itself.
+
+#### Scenario: Clean escalation to existing provider policy
+
+GIVEN a refused, unvalidated, uncertain, `escalation_required`, or authority-forbidden local
+task
+WHEN the worker concludes
+THEN it SHALL record a structured escalation decision targeting the existing provider policy.
+
+#### Scenario: Local Qwen has no reviewer/auditor/merge authority
+
+GIVEN the local worker capability
+WHEN its authorities are enumerated
+THEN it SHALL grant NO review, audit, merge, or approve authority to local Qwen
+AND such roles SHALL remain absent from its supported role set.
+
+#### Scenario: Execution evidence is minimal and structured
+
+GIVEN a completed local worker run
+WHEN evidence is emitted
+THEN it SHALL contain at least: provider (`ollama`), canonical model identity, task class,
+attempt number, result class, validation result, and escalation decision.

--- a/openspec/changes/minimal-local-worker-bootstrap/tasks.md
+++ b/openspec/changes/minimal-local-worker-bootstrap/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: Minimal Local Worker Bootstrap
+
+Instructions: treat `specs/minimal-local-worker-bootstrap/spec.md` as behavioral authority.
+Every task must have a completion signal; keep scope to the active change only.
+
+## Task 1 — Canonical model identity and constants
+- Add `minime/local_worker/model_identity.py` with:
+  - `OLLAMA_PROVIDER = "ollama"`
+  - `LOCAL_WORKER_ROLE = "local_worker"` (implement-oriented, never reviewer/auditor)
+  - `QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M = "qwen2.5-coder:7b-instruct-q4_K_M"`
+  - exact-equality helper.
+- Completion: unit test asserting the exact canonical string and exact-equality behavior. ✅
+
+## Task 2 — Local worker task classes and forbidden surfaces
+- Add `minime/local_worker/task_classes.py` declaring the allowlist
+  (`SMALL_CODE_FIX`, `TEST_AUTHORING`, `LOG_ANALYSIS`, `SMALL_REFACTOR`,
+  `API_SMALL_CHANGE`, `UI_SMALL_POLISH`) and forbidden-surface matchers for
+  lifecycle/state-machine, provider-policy, security, migrations/db-schema, architecture,
+  deployment/runtime-infrastructure, destructive, uncertain-classification.
+- Completion: ruff-clean module plus unit tests asserting allowlist membership and that each
+  forbidden surface is matched.
+
+## Task 3 — Local worker domain models (structured, deterministic)
+- Add `minime/local_worker/models.py` defining Pydantic v2:
+  - `LocalTaskEnvelope` (role, task_class, allowed_* , forbidden_* , smallest-patch
+    instruction, bounded context, no-architecture, no-unrelated-dependencies)
+  - `LocalWorkerResult` structured outputs with confidence, escalation_required,
+    escalation_reason and a valid `NO_CHANGE_JUSTIFIED` representation
+  - `PreflightResult`, `EligibilityDecision`, `ValidationResult`, `EscalationDecision`
+  - `LocalExecutionEvidence` (provider, model, task_class, attempt, result, validation,
+    escalation)
+- Completion: models import cleanly and serialize with ruff passing. ✅
+
+## Task 4 — Minimal Ollama adapter (offline-testable)
+- Add `minime/local_worker/ollama_adapter.py`:
+  - preflight reachability (`/api/tags`) and model existence (`/api/show`/tags equality)
+  - bounded generate that maps outcomes onto `minime.domain.enums.ProviderResultClass`
+  - injected `httpx.AsyncClient`/transport for offline tests
+  - timeout/cancellation and cleanup on deadline
+- Completion: unit tests (MockTransport) for reachability, model-present, model-missing,
+  generate success/failure and no-live-Ollama requirement all pass.
+
+## Task 5 — Eligibility and authority policy
+- Add `minime/local_worker/policy.py`:
+  - `evaluate_eligibility(task)` LOW-risk admission gate (allowlist + forbidden surfaces +
+    files)
+  - `local_worker_authorities()` prove no review/audit/merge/approve authority
+  - escalation decision to existing provider policy
+- Completion: unit tests for accepted allowed class and refused forbidden classes and the
+  no-authority set.
+
+## Task 6 — Bounded harness
+- Add `minime/local_worker/harness.py` with timeout/cancellation/cleanup, structured parse,
+  deterministic-validator callback, and a corrective cap of exactly ONE local attempt.
+- Completion: tests for timeout, bounded single corrective attempt, no-unbounded-retry,
+  timeout cleanup and NO_CHANGE_JUSTIFIED acceptance.
+
+## Task 7 — LocalWorkerService orchestration + evidence
+- Add `minime/local_worker/service.py` that maps preflight -> eligibility -> dispatch ->
+  validation -> evidence with escalation on refusal/failure/self-approval avoidance.
+- Completion: unit tests producing `LocalExecutionEvidence` for a successful low-risk run.
+
+## Task 8 — OpenSpec artifacts present & deterministic validation harness
+- Ensure `openspec/changes/minimal-local-worker-bootstrap/{proposal,design,tasks}.md` and
+  `specs/minimal-local-worker-bootstrap/spec.md` exist and are consistent.
+- Wire deterministic validation to use scope/diff guard + ruff checks (no live Ollama).
+- Completion: ruff passes, full focused test module runs, full pytest suite green when offline.
+
+## Task 9 — Verify no authority/self-approval and clean escalation
+- Add/finalize tests for the reviewer-independence + no merge authority and clean escalation
+  scenarios.
+- Completion: exact evidence fields asserted.
+
+### Acceptance / failure-injection tasks
+- T5 acceptance: forbidden classes never executed; evidence shows refusal + escalation.
+- T6 failure-injection: simulated validator failure leads to exactly 1 corrective attempt
+  then escalation, not N repeats.

--- a/src/minime/local_worker/harness.py
+++ b/src/minime/local_worker/harness.py
@@ -1,0 +1,229 @@
+"""Bounded local worker harness: timeout/cancel/cleanup + at most one corrective attempt.
+
+Every attempt runs under an asyncio deadline; a missed deadline cancels in-flight work and
+invokes ``cleanup``. Deterministic validation (mini me, never the model) decides success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+
+from minime.local_worker.model_identity import local_qwen_model_identity
+from minime.local_worker.models import (
+    EscalationDecision,
+    EscalationTarget,
+    LocalExecutionEvidence,
+    LocalResultKind,
+    LocalTaskEnvelope,
+    LocalValidationVerdict,
+    LocalWorkerResult,
+    ValidationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+_FENCE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+
+# Dispatch returns the model's raw bounded text answer for a given attempt number.
+Dispatch = Callable[[LocalTaskEnvelope, int], Awaitable[str]]
+# Deterministic validation authority.
+Validator = Callable[[LocalTaskEnvelope, LocalWorkerResult, int], Awaitable[ValidationResult]]
+Cleanup = Callable[[int], Awaitable[None] | None]
+
+
+def _first_json(text: str) -> str:
+    text = (_FENCE.search(text) or [None, text])[1]
+    start = text.find("{")
+    if start < 0:
+        return text
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return text
+
+
+def parse_structured_result(raw: str) -> LocalWorkerResult:
+    """Parse constrained bounded JSON into a structured result."""
+    payload_raw = _first_json(raw)
+    try:
+        payload = json.loads(payload_raw)
+    except ValueError as exc:
+        raise ValueError(f"Model output is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Model output is not a JSON object")
+
+    kind_val = str(payload.get("kind", "")).upper()
+    if kind_val == "NO_CHANGE_JUSTIFIED":
+        kind = LocalResultKind.NO_CHANGE_JUSTIFIED
+    elif kind_val in {"CHANGES_PROPOSED", ""}:
+        kind = LocalResultKind.CHANGES_PROPOSED
+    else:
+        kind = LocalResultKind.UNCERTAIN
+    try:
+        confidence = float(payload.get("confidence", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    return LocalWorkerResult(
+        kind=kind,
+        summary=str(payload.get("summary", "")),
+        files_changed=[str(item) for item in payload.get("files_changed", [])],
+        confidence=confidence,
+        escalation_required=bool(payload.get("escalation_required", False)),
+        escalation_reason=str(payload.get("escalation_reason", "")),
+        next_action=str(payload.get("next_action", "")),
+    )
+
+
+class LocalWorkerHarness:
+    """Deterministic-boundedness harness: deadline per attempt, one corrective, no self-ok."""
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        dispatch: Dispatch | None = None,
+        cleanup: Cleanup | None = None,
+        max_corrective_attempts: int = 1,
+    ) -> None:
+        self.model = model or local_qwen_model_identity()
+        self._dispatch = dispatch
+        self._cleanup = cleanup
+        # Spec: exactly one corrective attempt after a failed initial one.
+        self.max_corrective_attempts = max(0, int(max_corrective_attempts))
+        self.timeout_cleanup_calls = 0
+
+    async def run(self, task: LocalTaskEnvelope, *, validator: Validator) -> LocalExecutionEvidence:
+        """Run under the deadline, cancelling and cleaning up (never unbounded)."""
+        dispatch = self._dispatch
+        if dispatch is None:
+            raise ValueError("No dispatch callable configured")
+        cleanup = self._cleanup
+        corrections = 0
+        validated = False
+        last: LocalWorkerResult | None = None
+        last_validation = ValidationResult(
+            verdict=LocalValidationVerdict.NOT_APPLICABLE, reason="no result"
+        )
+        outcome_class = "NO_RESULT"
+        outcome_kind = LocalResultKind.UNCERTAIN
+        escalation: EscalationDecision | None = None
+        attempt = 1
+
+        while True:
+            raw = await self._bounded(task, attempt, dispatch, cleanup)
+            if raw is None:
+                outcome_class = "TIMEOUT"
+                last = None
+                last_validation = ValidationResult(
+                    verdict=LocalValidationVerdict.FAIL,
+                    reason="Bounded execution deadline exceeded and in-flight work was cancelled",
+                )
+                escalation = escalation or EscalationDecision(
+                    required=True,
+                    target=EscalationTarget.EXISTING_PROVIDER_POLICY,
+                    reason="Local worker timed out; escalate to existing provider policy",
+                )
+                break
+
+            try:
+                result = parse_structured_result(raw)
+            except ValueError as exc:
+                if corrections >= self.max_corrective_attempts:
+                    outcome_class = "MALFORMED_OUTPUT"
+                    last = None
+                    last_validation = ValidationResult(
+                        verdict=LocalValidationVerdict.FAIL,
+                        reason=f"Malformed structured output; corrective budget exhausted: {exc}",
+                    )
+                    escalation = escalation or EscalationDecision(
+                        required=True,
+                        target=EscalationTarget.EXISTING_PROVIDER_POLICY,
+                        reason="Local worker produced malformed structured output; escalate",
+                    )
+                    break
+                corrections += 1
+                attempt += 1
+                continue
+
+            last = result
+            last_validation = await validator(task, result, attempt)
+            if last_validation.passed:
+                validated = True
+                outcome_kind = result.kind
+                outcome_class = "SUCCESS"
+                break
+
+            if corrections >= self.max_corrective_attempts:
+                outcome_kind = result.kind
+                outcome_class = "VALIDATION_FAILED"
+                escalation = escalation or EscalationDecision(
+                    required=True,
+                    target=EscalationTarget.EXISTING_PROVIDER_POLICY,
+                    reason="Deterministic validation failed after the single corrective budget; escalate",
+                )
+                break
+
+            # Next loop iteration is the single corrective attempt (max allowed).
+            corrections += 1
+            attempt += 1
+
+        # Resolve the escalation decision from observed outcome.
+        if last is not None and escalation is None:
+            if validated and last.escalation_required:
+                escalation = EscalationDecision(
+                    required=True,
+                    target=EscalationTarget.EXISTING_PROVIDER_POLICY,
+                    reason=last.escalation_reason
+                    or "Structured result requested escalation to existing provider policy",
+                )
+            else:
+                escalation = EscalationDecision(
+                    required=False, target=EscalationTarget.NONE
+                )
+        else:
+            escalation = escalation or EscalationDecision(
+                required=False, target=EscalationTarget.NONE
+            )
+
+        return LocalExecutionEvidence(
+            provider="ollama",
+            model=self.model,
+            task_class=task.task_class.value,
+            attempt=max(attempt, 1),
+            result=outcome_kind,
+            result_class=outcome_class,
+            validation_result=last_validation.verdict,
+            escalation=escalation,
+            summary=(last.summary if last else ""),
+            corrections_used=corrections,
+        )
+
+    async def _bounded(
+        self,
+        task: LocalTaskEnvelope,
+        attempt: int,
+        dispatch: Dispatch,
+        cleanup: Cleanup | None,
+    ) -> str | None:
+        """Dispatch under task.timeout_seconds, cancelling and cleaning up on timeout."""
+        try:
+            return await asyncio.wait_for(dispatch(task, attempt), timeout=task.timeout_seconds)
+        except asyncio.TimeoutError:
+            logger.warning("Local worker dispatch attempt %s exceeded its deadline", attempt)
+            if cleanup is not None:
+                try:
+                    await cleanup(attempt)
+                except Exception:  # noqa: BLE001 - cleanup never masks the timeout signal
+                    logger.exception("Local worker timeout cleanup failed on attempt %s", attempt)
+            self.timeout_cleanup_calls += 1
+            return None
+

--- a/src/minime/local_worker/model_identity.py
+++ b/src/minime/local_worker/model_identity.py
@@ -1,0 +1,40 @@
+"""Canonical local worker provider/model identity for the minimal local worker bootstrap.
+
+The local worker capability executes bounded LOW-risk coding work through a single local
+Ollama model whose identity is exact and self-describing. The same provider/model must never
+be granted review, audit or merge authority for a candidate it substantively produced.
+"""
+
+from __future__ import annotations
+
+OLLAMA_PROVIDER = "ollama"
+
+# Implement-oriented role only. Local Qwen provider never claims reviewer/auditor roles.
+LOCAL_WORKER_ROLE = "local_worker"
+
+# Exact canonical model identity for the minimal local worker bootstrap.
+QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M = "qwen2.5-coder:7b-instruct-q4_K_M"
+
+# Authorities local Qwen is explicitly forbidden from exercising.
+LOCAL_QWEN_FORBIDDEN_AUTHORITIES = frozenset(
+    {"review", "audit", "merge", "approve", "validate_self_success"}
+)
+
+
+def local_qwen_model_identity() -> str:
+    """Return the single canonical model identity for the local worker."""
+    return QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M
+
+
+def is_canonical_local_qwen_model(model: str) -> bool:
+    """Return True only when ``model`` exactly matches the canonical identity."""
+    return model == QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M
+
+
+def assert_local_qwen_model(model: str, *, field: str = "model") -> None:
+    """Raise ValueError when ``model`` is not the exact canonical local Qwen identity."""
+    if not is_canonical_local_qwen_model(model):
+        raise ValueError(
+            f"{field} must be the exact canonical local Qwen model "
+            f"'{QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M}', got '{model}'"
+        )

--- a/src/minime/local_worker/models.py
+++ b/src/minime/local_worker/models.py
@@ -1,0 +1,162 @@
+"""Deterministic models for the minimal local worker bootstrap.
+
+These models describe a constrained LOW-risk local (Ollama/Qwen) task envelope, its
+structured output, preflight/eligibility/validation results, escalation, and the minimal
+flat execution evidence record. They contain no operational mutable state such as quota or
+process ids; they are pure, serializable domain records.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from minime.local_worker.model_identity import OLLAMA_PROVIDER
+
+
+class LocalTaskClass(str, Enum):
+    """Canonical LOW-risk task classes for the local worker."""
+
+    SMALL_CODE_FIX = "SMALL_CODE_FIX"
+    TEST_AUTHORING = "TEST_AUTHORING"
+    LOG_ANALYSIS = "LOG_ANALYSIS"
+    SMALL_REFACTOR = "SMALL_REFACTOR"
+    API_SMALL_CHANGE = "API_SMALL_CHANGE"
+    UI_SMALL_POLISH = "UI_SMALL_POLISH"
+
+
+class PreflightStatus(str, Enum):
+    READY = "READY"
+    NOT_READY = "NOT_READY"
+    UNREACHABLE = "UNREACHABLE"
+    MODEL_MISSING = "MODEL_MISSING"
+    NOT_QUALIFIED = "NOT_QUALIFIED"
+
+
+class EligibilityVerdict(str, Enum):
+    ADMIT = "ADMIT"
+    REFUSE = "REFUSE"
+
+
+class EscalationTarget(str, Enum):
+    NONE = "NONE"
+    EXISTING_PROVIDER_POLICY = "EXISTING_PROVIDER_POLICY"
+
+
+class LocalResultKind(str, Enum):
+    CHANGES_PROPOSED = "CHANGES_PROPOSED"
+    NO_CHANGE_JUSTIFIED = "NO_CHANGE_JUSTIFIED"
+    UNCERTAIN = "UNCERTAIN"
+
+
+class LocalValidationVerdict(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class LocalTaskEnvelope(BaseModel):
+    """Explicit role + allowed/forbidden surfaces + smallest-patch instruction context."""
+
+    role: str = Field(description="Explicit worker role (LOCAL_WORKER).")
+    task_class: LocalTaskClass
+    allowed_files: list[str] = Field(
+        default_factory=list, description="Explicit allowlist of files/globs the work may touch."
+    )
+    forbidden_files: list[str] = Field(
+        default_factory=list, description="Files/surfaces the work must never touch."
+    )
+    instruction: str = Field(
+        min_length=1, description="Smallest-patch instruction; no architecture redesign."
+    )
+    context: str = Field(
+        default="", description="Bounded context only; no unrelated repository surface."
+    )
+    no_architecture: bool = True
+    no_unrelated_dependencies: bool = True
+    max_output_tokens: int = 2048
+    timeout_seconds: float = 60.0
+
+
+class LocalWorkerResult(BaseModel):
+    """Constrained structured output of the local model.
+
+    ``NO_CHANGE_JUSTIFIED`` is a valid result the model may choose. Qwen never decides that
+    its own work is successful; deterministic validation decides that from real side-effects.
+    """
+
+    kind: LocalResultKind = LocalResultKind.CHANGES_PROPOSED
+    summary: str = ""
+    files_changed: list[str] = Field(default_factory=list)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    escalation_required: bool = False
+    escalation_reason: str = Field(default="", description="Required when escalation_required.")
+    next_action: str = Field(
+        default="",
+        description="e.g. 'apply_patch', 'no_change', or free-form next step.",
+    )
+
+    @property
+    def is_no_change_justified(self) -> bool:
+        return self.kind is LocalResultKind.NO_CHANGE_JUSTIFIED
+
+
+class PreflightResult(BaseModel):
+    provider: str
+    model: str
+    status: PreflightStatus
+    reason: str = ""
+    reachable: bool = False
+    model_present: bool = False
+
+
+class EligibilityDecision(BaseModel):
+    verdict: EligibilityVerdict
+    task_class: str
+    model: str
+    reason: str = ""
+    forbidden_surface: str | None = None
+    escalation_target: EscalationTarget = EscalationTarget.NONE
+
+    @property
+    def admitted(self) -> bool:
+        return self.verdict is EligibilityVerdict.ADMIT
+
+
+class ValidationResult(BaseModel):
+    verdict: LocalValidationVerdict
+    authority: str = "deterministic"
+    reason: str = ""
+    evidence: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return self.verdict is LocalValidationVerdict.PASS
+
+
+class EscalationDecision(BaseModel):
+    required: bool = False
+    target: EscalationTarget = EscalationTarget.NONE
+    reason: str = ""
+
+
+class LocalExecutionEvidence(BaseModel):
+    """Minimal structured evidence: provider, model, task class, attempt, result,
+    validation result, escalation."""
+
+    provider: str = OLLAMA_PROVIDER
+    model: str
+    task_class: str
+    attempt: int = 1  # starts at initial attempt; corrective attempt uses 2
+    result: LocalResultKind
+    result_class: str
+    validation_result: LocalValidationVerdict
+    escalation: EscalationDecision = Field(default_factory=EscalationDecision)
+    summary: str = ""
+    corrections_used: int = 0
+
+    @property
+    def fully_validated(self) -> bool:
+        return self.validation_result is LocalValidationVerdict.PASS

--- a/src/minime/local_worker/ollama_adapter.py
+++ b/src/minime/local_worker/ollama_adapter.py
@@ -1,0 +1,221 @@
+"""Minimal local/Ollama provider adapter for the local worker bootstrap.
+
+The adapter performs deterministic preflight (reachability + canonical model existence) and
+bounded generation through Ollama's HTTP API. It never runs live in tests: callers inject an
+``httpx.AsyncClient`` backed by ``httpx.MockTransport`` so all test scenarios run offline.
+
+Timeout enforces the bounded-execution guarantee; cancellation and cleanup of the in-flight
+request is delegated to the HTTP layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from minime.domain.enums import ProviderResultClass
+from minime.local_worker.model_identity import OLLAMA_PROVIDER
+from minime.local_worker.models import PreflightResult, PreflightStatus
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
+
+
+@dataclass(frozen=True)
+class OllamaGenerateResponse:
+    result_class: ProviderResultClass
+    text: str = ""
+    done: bool = False
+    error: str = ""
+
+
+class LocalOllamaAdapter:
+    """Thin, deterministic Ollama adapter with offline-testable injected transport."""
+
+    def __init__(
+        self,
+        model: str,
+        base_url: str = DEFAULT_OLLAMA_BASE_URL,
+        request_timeout_seconds: float = 30.0,
+    ) -> None:
+        self.provider = OLLAMA_PROVIDER
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.request_timeout_seconds = request_timeout_seconds
+
+    async def _client(self, client: httpx.AsyncClient | None) -> httpx.AsyncClient:
+        if client is not None:
+            return client
+        return httpx.AsyncClient(base_url=self.base_url, timeout=self.request_timeout_seconds)
+
+    @staticmethod
+    def _parse_tags_model_names(raw: bytes | str) -> list[str]:
+        try:
+            payload = json.loads(raw if isinstance(raw, str) else raw.decode("utf-8", "replace"))
+        except (ValueError, UnicodeDecodeError):
+            return []
+        models = payload.get("models", []) if isinstance(payload, dict) else []
+        names: list[str] = []
+        for entry in models:
+            if isinstance(entry, dict):
+                name = entry.get("name") or entry.get("model")
+                if name:
+                    names.append(str(name))
+        return names
+
+    async def preflight(
+        self, *, client: httpx.AsyncClient | None = None
+    ) -> PreflightResult:
+        """Reachability + canonical-model-existence preflight.
+
+        Reachability: GET /api/tags returns 200 -> reachable.
+        Model presence: response model names exactly contain the canonical identity.
+        """
+        async with await self._client(client) as active:
+            try:
+                res = await asyncio.wait_for(
+                    active.get("/api/tags"),
+                    timeout=self.request_timeout_seconds,
+                )
+            except asyncio.TimeoutError:
+                return PreflightResult(
+                    provider=self.provider,
+                    model=self.model,
+                    status=PreflightStatus.UNREACHABLE,
+                    reason="Ollama unreachable: /api/tags timed out",
+                    reachable=False,
+                    model_present=False,
+                )
+            except httpx.HTTPError:
+                return PreflightResult(
+                    provider=self.provider,
+                    model=self.model,
+                    status=PreflightStatus.UNREACHABLE,
+                    reason="Ollama unreachable: /api/tags request error",
+                    reachable=False,
+                    model_present=False,
+                )
+
+        if res.status_code != 200:
+            return PreflightResult(
+                provider=self.provider,
+                model=self.model,
+                status=PreflightStatus.UNREACHABLE,
+                reason=f"Ollama unreachable: /api/tags returned HTTP {res.status_code}",
+                reachable=False,
+                model_present=False,
+            )
+
+        names = self._parse_tags_model_names(res.content)
+        present = self.model in names
+        if not present:
+            return PreflightResult(
+                provider=self.provider,
+                model=self.model,
+                status=PreflightStatus.MODEL_MISSING,
+                reason=f"Required model '{self.model}' is not present in the local Ollama registry",
+                reachable=True,
+                model_present=False,
+            )
+
+        return PreflightResult(
+            provider=self.provider,
+            model=self.model,
+            status=PreflightStatus.READY,
+            reason="Ollama reachable and required model present",
+            reachable=True,
+            model_present=True,
+        )
+
+    async def generate(
+        self,
+        *,
+        system_prompt: str,
+        prompt: str,
+        client: httpx.AsyncClient | None = None,
+        timeout_seconds: float | None = None,
+    ) -> OllamaGenerateResponse:
+        """Send one bounded chat/generate request and return the normalized result.
+
+        Bounded time is enforced via ``asyncio.wait_for`` so a stalled local model cannot run
+        indefinitely. Cancellation propagates through the async request; the harness layer
+        supplies overall process/cancellation cleanup semantics.
+        """
+        deadline_s = timeout_seconds or max(1.0, self.request_timeout_seconds)
+        body = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            "stream": False,
+            "options": {"temperature": 0.0},
+        }
+        async with await self._client(client) as active:
+            try:
+                res = await asyncio.wait_for(
+                    active.post("/api/chat", json=body),
+                    timeout=deadline_s,
+                )
+            except asyncio.TimeoutError:
+                return OllamaGenerateResponse(
+                    result_class=ProviderResultClass.TIMEOUT,
+                    error="Ollama generate timed out and was cancelled",
+                )
+            except httpx.HTTPError as exc:
+                return OllamaGenerateResponse(
+                    result_class=ProviderResultClass.UNKNOWN_ERROR,
+                    error=f"Ollama generate HTTP error: {exc.__class__.__name__}",
+                )
+
+        if res.status_code != 200:
+            response_class = (
+                ProviderResultClass.RATE_LIMIT
+                if res.status_code == 429
+                else (
+                    ProviderResultClass.TRANSIENT_ERROR
+                    if res.status_code >= 500
+                    else ProviderResultClass.UNKNOWN_ERROR
+                )
+            )
+            return OllamaGenerateResponse(
+                result_class=response_class,
+                error=f"Ollama generate HTTP {res.status_code}: {res.text[:300]}",
+            )
+
+        try:
+            payload = res.json()
+        except ValueError:
+            return OllamaGenerateResponse(
+                result_class=ProviderResultClass.MALFORMED_OUTPUT,
+                error="Ollama generate returned non-JSON body",
+            )
+
+        if isinstance(payload, dict) and payload.get("error"):
+            return OllamaGenerateResponse(
+                result_class=ProviderResultClass.UNKNOWN_ERROR,
+                error=str(payload.get("error"))[:300],
+            )
+
+        if isinstance(payload, dict) and payload.get("message"):
+            text = str(payload.get("message", {}).get("content", ""))
+        else:
+            text = str(payload.get("response", "")) if isinstance(payload, dict) else ""
+
+        if not text.strip():
+            return OllamaGenerateResponse(
+                result_class=ProviderResultClass.MALFORMED_OUTPUT,
+                error="Ollama generate returned empty content",
+            )
+
+        return OllamaGenerateResponse(
+            result_class=ProviderResultClass.SUCCESS,
+            text=text,
+            done=bool(payload.get("done", True)),
+        )
+

--- a/src/minime/local_worker/policy.py
+++ b/src/minime/local_worker/policy.py
@@ -1,0 +1,155 @@
+"""Deterministic local worker policy: LOW-risk eligibility, authority, escalation.
+
+The eligibility gate and authority sets are decided deterministically by mini me, never by
+the model. Local Qwen executes only admissible LOW-risk envelopes and never carries
+review/audit/merge/approve authority.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+
+from minime.local_worker.model_identity import (
+    LOCAL_QWEN_FORBIDDEN_AUTHORITIES,
+    OLLAMA_PROVIDER,
+    local_qwen_model_identity,
+)
+from minime.local_worker.models import (
+    EligibilityDecision,
+    EligibilityVerdict,
+    EscalationDecision,
+    EscalationTarget,
+    LocalTaskClass,
+)
+from minime.local_worker.task_classes import (
+    ForbiddenSurfaceKind,
+    offending_forbidden_surface,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def local_worker_authorities(*, model: str | None = None) -> frozenset[str]:
+    """Return the authority labels the local Qwen worker is allowed (implement only).
+
+    Reviewer/audit/merge/approve and self-approval labels are always excluded for local Qwen,
+    mirroring the canonical rule that the same provider/model never reviews its own work.
+    """
+    if model is not None and model != local_qwen_model_identity():
+        logger.warning("Unknown local model identity requested for authority evaluation")
+    return frozenset({"implement"}) - LOCAL_QWEN_FORBIDDEN_AUTHORITIES
+
+
+def evaluate_eligibility(
+    *,
+    task_class: str,
+    instruction: str,
+    allowed_files: list[str] | None = None,
+    forbidden_files: list[str] | None = None,
+    touched_files: list[str] | None = None,
+) -> EligibilityDecision:
+    """Evaluate a LOW-risk task for LOCAL execution.
+
+    Admit only when the class is allowlisted and no forbidden surface/file is touched.
+    Otherwise refuse with a deterministic reason and an escalation target.
+    """
+    model = local_qwen_model_identity()
+    surface_names = list(forbidden_files or [])
+    surface_names.extend(touched_files or [])
+    forbidden = offending_forbidden_surface(
+        task_description=instruction,
+        touched_surfaces=surface_names,
+        task_class=task_class,
+    )
+
+    if forbidden is not None:
+        reason = (
+            f"Task class '{task_class}' is not a canonical LOW-risk allowlisted class"
+            if not allowed_local(task_class)
+            else f"Task touches forbidden surface '{forbidden.value}'"
+        )
+        return EligibilityDecision(
+            verdict=EligibilityVerdict.REFUSE,
+            task_class=task_class,
+            model=model,
+            reason=reason,
+            forbidden_surface=forbidden.value,
+            escalation_target=EscalationTarget.EXISTING_PROVIDER_POLICY,
+        )
+
+    # Even when the surface scan passes, enforce the allowlist via a file allowlist when one
+    # is declared: admittance is limited to the allowed_files set.
+    if allowed_files is not None and touched_files:
+        for touched in touched_files:
+            if not _within_allowlist(touched, allowed_files):
+                return EligibilityDecision(
+                    verdict=EligibilityVerdict.REFUSE,
+                    task_class=task_class,
+                    model=model,
+                    reason=f"Touched file '{touched}' is outside the explicit allowed_files allowlist",
+                    escalation_target=EscalationTarget.EXISTING_PROVIDER_POLICY,
+                )
+
+    return EligibilityDecision(
+        verdict=EligibilityVerdict.ADMIT,
+        task_class=task_class,
+        model=model,
+        reason=f"Task class '{task_class}' admitted for LOW-risk local execution",
+    )
+
+
+def allowed_local(task_class: str) -> bool:
+    from minime.local_worker.task_classes import allowed_local_task_class
+
+    return allowed_local_task_class(task_class)
+
+
+def _within_allowlist(path: str, allowed_files: list[str]) -> bool:
+    for pattern in allowed_files:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+    return False
+
+
+def decision_as_escalation(
+    decision: EligibilityDecision | None = None,
+    *,
+    reason: str = "",
+) -> EscalationDecision:
+    """Build a clean escalation to the existing provider policy when warranted."""
+    required = False
+    aggregated = reason
+    if decision is not None and decision.verdict is EligibilityVerdict.REFUSE:
+        required = True
+        aggregated = decision.reason if not aggregated else f"{decision.reason}; {aggregated}"
+    if not required and not aggregated:
+        return EscalationDecision(required=False, target=EscalationTarget.NONE)
+    return EscalationDecision(
+        required=required or bool(aggregated),
+        target=EscalationTarget.EXISTING_PROVIDER_POLICY,
+        reason=aggregated or "Escalation to existing provider policy",
+    )
+
+
+def assert_no_local_authority(*, authority: str) -> None:
+    """Raise if ``authority`` is forbidden for local Qwen (e.g. 'review', 'audit', 'merge')."""
+    normalized = authority.strip().lower()
+    if normalized in LOCAL_QWEN_FORBIDDEN_AUTHORITIES or normalized not in {
+        "implement"
+    }:
+        raise PermissionError(
+            f"Local Qwen has no '{authority}' authority. It may only implement. "
+            "Use the existing provider policy for reviewer/audit/merge/approve gates."
+        )
+
+
+__all__ = [
+    "ForbiddenSurfaceKind",
+    "LocalTaskClass",
+    "OLLAMA_PROVIDER",
+    "assert_no_local_authority",
+    "decision_as_escalation",
+    "evaluate_eligibility",
+    "local_worker_authorities",
+]

--- a/src/minime/local_worker/service.py
+++ b/src/minime/local_worker/service.py
@@ -1,0 +1,187 @@
+"""LocalWorkerService: eligibility -> preflight -> bounded dispatch -> validation -> evidence.
+
+Mini me decides success deterministically; the local Qwen model only produces a constrained
+candidate result and never approves its own work.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+import httpx
+
+from minime.domain.enums import ProviderResultClass
+from minime.local_worker.harness import LocalWorkerHarness
+from minime.local_worker.model_identity import (
+    LOCAL_WORKER_ROLE,
+    OLLAMA_PROVIDER,
+    assert_local_qwen_model,
+    local_qwen_model_identity,
+)
+from minime.local_worker.models import (
+    EscalationDecision,
+    EscalationTarget,
+    LocalExecutionEvidence,
+    LocalResultKind,
+    LocalTaskEnvelope,
+    LocalValidationVerdict,
+    LocalWorkerResult,
+    PreflightResult,
+    PreflightStatus,
+    ValidationResult,
+)
+from minime.local_worker.ollama_adapter import LocalOllamaAdapter
+from minime.local_worker.policy import evaluate_eligibility
+
+logger = logging.getLogger(__name__)
+
+Validator = Callable[
+    [LocalTaskEnvelope, LocalWorkerResult, int], Awaitable[ValidationResult]
+]
+
+SYSTEM_PROMPT = (
+    "You are the mini me local worker. Take only the smallest possible patch within the "
+    "strict allowed files; never redesign architecture. Reply ONLY with a flat JSON object "
+    '{"kind":"CHANGES_PROPOSED"|"NO_CHANGE_JUSTIFIED","summary":"...","files_changed":[],'
+    '"confidence":0.0,"escalation_required":false,"escalation_reason":"",'
+    '"next_action":"..."}. You do not decide success; mini me does, deterministically.'
+)
+
+
+class LocalWorkerService:
+    """Bounded LOW-risk local worker orchestration with injected transport."""
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        adapter: LocalOllamaAdapter | None = None,
+        max_corrective_attempts: int = 1,
+    ) -> None:
+        self.model = model or local_qwen_model_identity()
+        assert_local_qwen_model(self.model)
+        self.adapter = adapter or LocalOllamaAdapter(model=self.model)
+        self.harness = LocalWorkerHarness(
+            model=self.model, max_corrective_attempts=max_corrective_attempts
+        )
+
+    async def run(
+        self,
+        task: LocalTaskEnvelope,
+        *,
+        validator: Validator,
+        client: httpx.AsyncClient | None = None,
+        preflight: PreflightResult | None = None,
+    ):
+        """Eligibility gate -> preflight -> bounded dispatch -> validation -> evidence."""
+        eligibility = evaluate_eligibility(
+            task_class=task.task_class.value,
+            instruction=task.instruction,
+            allowed_files=task.allowed_files,
+            forbidden_files=task.forbidden_files,
+        )
+        if not eligibility.admitted:
+            return _refusal(eligibility)
+
+        preflight = preflight or await self.adapter.preflight(client=client)
+        if preflight.status is not PreflightStatus.READY:
+            return ServiceOutcome(eligibility, preflight, _preflight_failed_evidence(preflight))
+
+        async def bounded_dispatch(envelope: LocalTaskEnvelope, attempt: int) -> str:
+            body = (
+                envelope.instruction
+                + "\nAllowed: "
+                + ", ".join(envelope.allowed_files)
+                + "\nForbidden: "
+                + ", ".join(envelope.forbidden_files)
+                + "\nContext:\n"
+                + envelope.context
+            )
+            response = await self.adapter.generate(
+                system_prompt=SYSTEM_PROMPT,
+                prompt=f"{LOCAL_WORKER_ROLE}\n{body}",
+                client=client,
+            )
+            if response.result_class is not ProviderResultClass.SUCCESS:
+                return ""
+            return response.text
+
+        self.harness._dispatch = bounded_dispatch
+        self.harness._cleanup = None
+        try:
+            evidence = await self.harness.run(task, validator=validator)
+        except Exception:  # noqa: BLE001 - escalate, never crash the caller
+            logger.exception("Local worker execution failed unexpectedly")
+            evidence = _unexpected_failure_evidence(eligibility.task_class)
+        return ServiceOutcome(eligibility, preflight, evidence)
+
+
+class ServiceOutcome:
+    """Structured eligibility + preflight + evidence for one local run."""
+
+    def __init__(self, eligibility, preflight, evidence) -> None:
+        self.eligibility = eligibility
+        self.preflight = preflight
+        self.evidence = evidence
+
+
+def _escalate(reason: str) -> EscalationDecision:
+    """Clean escalation decision always routed to the existing provider policy."""
+    return EscalationDecision(
+        required=True, target=EscalationTarget.EXISTING_PROVIDER_POLICY, reason=reason
+    )
+
+
+def _refusal(eligibility) -> ServiceOutcome:
+    """Deterministic refusal outcome: never execute forbidden/uncertain local work."""
+    from minime.local_worker.models import PreflightResult
+
+    preflight = PreflightResult(
+        provider=OLLAMA_PROVIDER,
+        model=eligibility.model,
+        status=PreflightStatus.NOT_QUALIFIED,
+        reason=eligibility.reason,
+        reachable=False,
+        model_present=False,
+    )
+    evidence = LocalExecutionEvidence(
+        provider=OLLAMA_PROVIDER,
+        model=eligibility.model,
+        task_class=eligibility.task_class,
+        attempt=0,
+        result=LocalResultKind.UNCERTAIN,
+        result_class="REFUSED",
+        validation_result=LocalValidationVerdict.NOT_APPLICABLE,
+        escalation=_escalate(eligibility.reason),
+        summary=eligibility.reason,
+    )
+    return ServiceOutcome(eligibility, preflight, evidence)
+
+
+def _preflight_failed_evidence(preflight: PreflightResult) -> LocalExecutionEvidence:
+    return LocalExecutionEvidence(
+        provider=preflight.provider,
+        model=preflight.model,
+        task_class="NOT_STARTED",
+        attempt=0,
+        result=LocalResultKind.UNCERTAIN,
+        result_class="PREFLIGHT_FAILED",
+        validation_result=LocalValidationVerdict.NOT_APPLICABLE,
+        escalation=_escalate(preflight.reason or "Preflight for local worker not ready"),
+        summary=preflight.reason,
+    )
+
+
+def _unexpected_failure_evidence(task_class: str) -> LocalExecutionEvidence:
+    return LocalExecutionEvidence(
+        provider=OLLAMA_PROVIDER,
+        model=local_qwen_model_identity(),
+        task_class=task_class,
+        attempt=1,
+        result=LocalResultKind.UNCERTAIN,
+        result_class="UNEXPECTED_FAILURE",
+        validation_result=LocalValidationVerdict.FAIL,
+        escalation=_escalate("Unexpected local worker failure; escalate"),
+    )
+

--- a/src/minime/local_worker/task_classes.py
+++ b/src/minime/local_worker/task_classes.py
@@ -1,0 +1,219 @@
+"""Deterministic local worker task classes and forbidden surfaces.
+
+LOW-risk eligibility for the local worker is decided here deterministically and never by the
+model. Task classes follow the canonical allowlist defined by the minimal local worker
+bootstrap change; every other class and every known forbidden surface is refused.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+# Canonical LOW-risk task classes the local worker may execute.
+ALLOWED_LOCAL_TASK_CLASSES = frozenset(
+    {
+        "SMALL_CODE_FIX",
+        "TEST_AUTHORING",
+        "LOG_ANALYSIS",
+        "SMALL_REFACTOR",
+        "API_SMALL_CHANGE",
+        "UI_SMALL_POLISH",
+    }
+)
+
+UNKNOWN_CLASS = "UNKNOWN"
+UNCERTAIN_CLASSIFICATION = "UNCERTAIN_CLASSIFICATION"
+
+# Forbidden-surface keyword families. Matching is case-insensitive substring over the
+# normalized task description and touch-path surface strings.
+FORBIDDEN_SURFACE_FAMILIES: dict[str, tuple[str, ...]] = {
+    "lifecycle_state_machine": (
+        "lifecycle",
+        "state-machine",
+        "state machine",
+        "state_machine",
+        "transition key",
+        "workflow status",
+    ),
+    "provider_policy": (
+        "provider-policy",
+        "provider policy",
+        "provider_policy",
+        "policy change",
+        "policy_changes",
+        "retry budget",
+        "capacity policy",
+        "fallback policy",
+        "quota policy",
+    ),
+    "security_sensitive": (
+        "security",
+        "credential",
+        "secret",
+        "token",
+        "authn",
+        "authnz",
+        "authorization",
+        "authenticate",
+        "encrypt",
+        "tls",
+        "pki",
+    ),
+    "db_schema_migrations": (
+        "migration",
+        "alembic",
+        "ddl",
+        "database schema",
+        "schema change",
+        "db schema",
+    ),
+    "architecture": (
+        "architecture",
+        "architectural",
+        "interface redesign",
+        "structural subsystem",
+        "design doc",
+    ),
+    "deployment_runtime_infrastructure": (
+        "deployment",
+        "runtime infrastructure",
+        "infrastructure",
+        "systemd",
+        "docker",
+        "container",
+        "tunnel",
+        "server runtime",
+        "production",
+    ),
+    "destructive": (
+        "delete",
+        "drop ",
+        "truncate",
+        "reset --hard",
+        "force",
+        "rm -rf",
+        "destructive",
+        "purge",
+    ),
+    "uncertain_classification": (
+        "uncertain",
+        "ambiguous",
+        "unknown impact",
+        "classified",
+    ),
+}
+
+# Canonical forbidden high-risk task classes.
+FORBIDDEN_TASK_CLASSES = frozenset(
+    {
+        "LIFECYCLE_STATE_MACHINE_CHANGE",
+        "PROVIDER_POLICY_CHANGE",
+        "SECURITY_SENSITIVE_CHANGE",
+        "DB_SCHEMA_MIGRATION",
+        "ARCHITECTURE_CHANGE",
+        "DEPLOYMENT_RUNTIME_CHANGE",
+        "DESTRUCTIVE_OPERATION",
+        "UNCERTAIN_CLASSIFICATION",
+    }
+)
+
+# Files / surfaces that are never legal for a local worker touch.
+FORBIDDEN_FILE_SURFACE_KEYWORDS = frozenset(
+    {
+        "alembic",
+        "migrations",
+        ".env",
+        "*.pem",
+        "*.key",
+        "secrets",
+        "credentials",
+        "systemd",
+        "config/minime.yaml",
+        "pyproject.toml",
+        "docs/PROVIDER_POLICY.md",
+    }
+)
+
+
+class ForbiddenSurfaceKind(str, Enum):
+    """Stable identifiers for forbidden surface families."""
+
+    LIFECYCLE_STATE_MACHINE = "lifecycle_state_machine"
+    PROVIDER_POLICY = "provider_policy"
+    SECURITY_SENSITIVE = "security_sensitive"
+    DB_SCHEMA_MIGRATIONS = "db_schema_migrations"
+    ARCHITECTURE = "architecture"
+    DEPLOYMENT_RUNTIME_INFRASTRUCTURE = "deployment_runtime_infrastructure"
+    DESTRUCTIVE = "destructive"
+    UNCERTAIN_CLASSIFICATION = "uncertain_classification"
+
+
+def allowed_local_task_class(task_class: str) -> bool:
+    """Return True only if ``task_class`` is a canonical LOW-risk allowlisted class."""
+    return task_class.upper() in ALLOWED_LOCAL_TASK_CLASSES
+
+
+def forbidden_task_class_reason(task_class: str) -> str | None:
+    """Return a canonical forbidden label when ``task_class`` is not LOW-risk, else None.
+
+    The label is the specific forbidden class when known, otherwise
+    ``UNCERTAIN_CLASSIFICATION``. Allowed LOW-risk classes return None so surface scanning
+    may continue.
+    """
+    if allowed_local_task_class(task_class):
+        return None
+    upper = task_class.upper()
+    if upper in FORBIDDEN_TASK_CLASSES:
+        return upper
+    return UNCERTAIN_CLASSIFICATION
+
+
+def offending_forbidden_surface(
+    *,
+    task_description: str = "",
+    touched_surfaces: list[str] | None = None,
+    task_class: str = "",
+):
+    """Return the first offending ``ForbiddenSurfaceKind`` for a task envelope, or None.
+
+    ``touched_surfaces`` are file paths and/or surface names the task would touch. A task is
+    forbidden when its class is not a canonical LOW-risk allowlisted class, when its
+    description/surfaces match a forbidden family, or when a touched file matches a
+    forbidden file-surface keyword.
+
+    Because a non-allowed task class encodes uncertainty, it maps to
+    ``UNCERTAIN_CLASSIFICATION`` so the caller can treat it as high-risk.
+    """
+    class_reason = forbidden_task_class_reason(task_class)
+    if class_reason is not None:
+        if class_reason in FORBIDDEN_TASK_CLASSES:
+            # Map a specific forbidden class onto its surface kind when possible.
+            mapping = {
+                "LIFECYCLE_STATE_MACHINE_CHANGE": ForbiddenSurfaceKind.LIFECYCLE_STATE_MACHINE,
+                "PROVIDER_POLICY_CHANGE": ForbiddenSurfaceKind.PROVIDER_POLICY,
+                "SECURITY_SENSITIVE_CHANGE": ForbiddenSurfaceKind.SECURITY_SENSITIVE,
+                "DB_SCHEMA_MIGRATION": ForbiddenSurfaceKind.DB_SCHEMA_MIGRATIONS,
+                "ARCHITECTURE_CHANGE": ForbiddenSurfaceKind.ARCHITECTURE,
+                "DEPLOYMENT_RUNTIME_CHANGE": ForbiddenSurfaceKind.DEPLOYMENT_RUNTIME_INFRASTRUCTURE,
+                "DESTRUCTIVE_OPERATION": ForbiddenSurfaceKind.DESTRUCTIVE,
+            }
+            return mapping.get(class_reason, ForbiddenSurfaceKind.UNCERTAIN_CLASSIFICATION)
+        return ForbiddenSurfaceKind.UNCERTAIN_CLASSIFICATION
+
+    haystack = [task_description.lower()]
+    if touched_surfaces:
+        haystack.extend(s.lower() for s in touched_surfaces)
+
+    for kind, keywords in FORBIDDEN_SURFACE_FAMILIES.items():
+        for kw in keywords:
+            kwl = kw.lower()
+            if any(kwl in text for text in haystack):
+                return ForbiddenSurfaceKind(kind)
+
+    if touched_surfaces:
+        for surface in touched_surfaces:
+            lowered = surface.lower()
+            if any(kw in lowered for kw in FORBIDDEN_FILE_SURFACE_KEYWORDS):
+                return ForbiddenSurfaceKind.UNCERTAIN_CLASSIFICATION
+
+    return None

--- a/tests/test_local_worker_bootstrap.py
+++ b/tests/test_local_worker_bootstrap.py
@@ -1,0 +1,344 @@
+"""Offline tests for the minimal local worker bootstrap change.
+
+These tests require NO live Ollama daemon and NO model download: every network interaction
+runs through an injected ``httpx.MockTransport``, and eligibility/harness scenarios are fully
+deterministic. Mirrors the behavioral authority in
+``openspec/changes/minimal-local-worker-bootstrap/specs/.../spec.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from minime.local_worker.harness import LocalWorkerHarness, parse_structured_result
+from minime.local_worker.model_identity import (
+    QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M,
+    assert_local_qwen_model,
+    is_canonical_local_qwen_model,
+    local_qwen_model_identity,
+)
+from minime.local_worker.models import (
+    EscalationTarget,
+    LocalExecutionEvidence,
+    LocalResultKind,
+    LocalTaskClass,
+    LocalTaskEnvelope,
+    LocalValidationVerdict,
+    ValidationResult,
+)
+from minime.local_worker.ollama_adapter import LocalOllamaAdapter, OllamaGenerateResponse
+from minime.local_worker.policy import (
+    evaluate_eligibility,
+    local_worker_authorities,
+)
+
+COPY_PREFIX = "src/minime/local_worker/"
+
+# --- canonical model identity + no-authority (spec: exact identity, no merge/review/audit) ---
+
+
+def test_exact_canonical_model_identity():
+    assert QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M == "qwen2.5-coder:7b-instruct-q4_K_M"
+    assert local_qwen_model_identity() == "qwen2.5-coder:7b-instruct-q4_K_M"
+    assert is_canonical_local_qwen_model("qwen2.5-coder:7b-instruct-q4_K_M")
+    assert not is_canonical_local_qwen_model("qwen2.5-coder:7b")  # not exact
+    assert_local_qwen_model("qwen2.5-coder:7b-instruct-q4_K_M")
+
+
+def test_local_worker_has_no_review_audit_merge_approve_authority():
+    authorities = local_worker_authorities()
+    assert "implement" in authorities
+    for forbidden in ("review", "audit", "merge", "approve", "validate_self_success"):
+        assert forbidden not in authorities
+
+
+# --- eligibility admission / refusal (spec) ---
+
+
+def _envelope(task_class: LocalTaskClass, instruction: str) -> LocalTaskEnvelope:
+    return LocalTaskEnvelope(
+        role="local_worker",
+        task_class=task_class,
+        allowed_files=["src/minime/local_worker/*.py"],
+        forbidden_files=[],
+        instruction=instruction,
+        context="bounded test context",
+    )
+
+
+def test_allowed_low_risk_class_is_admitted():
+    decision = evaluate_eligibility(
+        task_class=LocalTaskClass.SMALL_CODE_FIX.value,
+        instruction="fix an off-by-one in the counting helper",
+        allowed_files=["src/**"],
+    )
+    assert decision.admitted
+
+
+@pytest.mark.parametrize(
+    "bad_class,instruction",
+    [
+        ("DB_SCHEMA_MIGRATION", "add an alembic revision"),
+        ("PROVIDER_POLICY_CHANGE", "change the retry budget"),
+        ("UNCERTAIN_CLASSIFICATION", "apply an ambiguous broad refactor"),
+        ("DESTRUCTIVE_OPERATION", "delete old data"),
+    ],
+)
+def test_forbidden_class_is_refused_with_escalation(bad_class, instruction):
+    decision = evaluate_eligibility(
+        task_class=bad_class,
+        instruction=instruction,
+        allowed_files=["src/**"],
+    )
+    assert not decision.admitted
+    assert decision.escalation_target is EscalationTarget.EXISTING_PROVIDER_POLICY
+
+
+def test_forbidden_surface_in_instruction_is_refused():
+    decision = evaluate_eligibility(
+        task_class=LocalTaskClass.SMALL_CODE_FIX.value,
+        instruction="tune the TLS credential handling",
+        allowed_files=["src/**"],
+    )
+    assert not decision.admitted
+
+
+# --- adapter offline (MockTransport), preflight reachability + model presence ---
+
+
+def _tags_response(names):
+    return httpx.Response(200, json={"models": [{"name": n} for n in names]})
+
+
+async def test_preflight_success_when_reachable_and_model_present():
+    transport = httpx.MockTransport(
+        lambda request: _tags_response([QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M])
+    )
+    client = httpx.AsyncClient(transport=transport, base_url="http://ollama.test")
+    adapter = LocalOllamaAdapter(model=QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M)
+    result = await adapter.preflight(client=client)
+    assert result.reachable is True
+    assert result.model_present is True
+
+
+async def test_preflight_fails_when_canonical_model_missing():
+    transport = httpx.MockTransport(lambda request: _tags_response(["llama3.1"]))
+    client = httpx.AsyncClient(transport=transport, base_url="http://ollama.test")
+    adapter = LocalOllamaAdapter(model=QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M)
+    result = await adapter.preflight(client=client)
+    assert result.model_present is False
+    assert QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M in result.reason
+
+
+async def test_preflight_fails_when_ollama_unreachable():
+    def handler(request):
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ollama.test"
+    )
+    adapter = LocalOllamaAdapter(model=QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M)
+    result = await adapter.preflight(client=client)
+    assert result.reachable is False
+
+
+async def test_generate_success_returns_bounded_text():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={
+                "message": {"role": "assistant", "content": '{"kind":"CHANGES_PROPOSED"}'}
+            },
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ollama.test"
+    )
+    adapter = LocalOllamaAdapter(model=QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M)
+    response = await adapter.generate(
+        system_prompt="s", prompt="p", client=client
+    )
+    assert isinstance(response, OllamaGenerateResponse)
+    assert response.text.startswith('{"kind"')
+
+
+async def test_generate_non_success_class_maps_onto_provider_class():
+    def handler(request):
+        return httpx.Response(500, text="boom")
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ollama.test"
+    )
+    adapter = LocalOllamaAdapter(model=QWEN2_5_CODER_7B_INSTRUCT_Q4_K_M)
+    response = await adapter.generate(system_prompt="s", prompt="p", client=client)
+    assert response.text == ""
+    assert response.error != ""
+
+
+# --- harness: structured parse, NO_CHANGE_JUSTIFIED acceptance, timeout, one-corrective cap ---
+
+
+async def _always_pass(_task, _result, _attempt) -> ValidationResult:
+    return ValidationResult(verdict=LocalValidationVerdict.PASS, reason="deterministic")
+
+
+async def _always_fail(_task, _result, _attempt) -> ValidationResult:
+    return ValidationResult(verdict=LocalValidationVerdict.FAIL, reason="not validated")
+
+
+async def test_parse_accepts_no_change_justified_as_valid():
+    result = parse_structured_result(
+        '{```json\n{"kind":"NO_CHANGE_JUSTIFIED","summary":"no change needed",'
+        '"files_changed":[],"confidence":0.9}\n```}'
+    )
+    assert result.kind is LocalResultKind.NO_CHANGE_JUSTIFIED
+    assert result.is_no_change_justified
+
+
+async def test_harness_accepts_no_change_justified_outcome_when_validated():
+    async def dispatch(_t, _n):
+        return '{"kind":"NO_CHANGE_JUSTIFIED","summary":"ok"}'
+
+    harness = LocalWorkerHarness(dispatch=dispatch)
+    envelope = _envelope(LocalTaskClass.SMALL_CODE_FIX, "look and decide no change needed")
+    envelope.timeout_seconds = 5.0
+    evidence = await harness.run(envelope, validator=lambda *a: _always_pass(*a))
+    assert evidence.result is LocalResultKind.NO_CHANGE_JUSTIFIED
+    assert evidence.validation_result is LocalValidationVerdict.PASS
+    assert evidence.escalation.required is False
+
+
+async def test_harness_timeout_cancels_in_flight_and_cleanup_called():
+    cleanup_calls = []
+
+    async def cleanup(attempt: int):
+        cleanup_calls.append(attempt)
+
+    async def slow_dispatch(_t, _n):
+        await asyncio.sleep(30)  # far beyond the envelope deadline
+
+    harness = LocalWorkerHarness(
+        dispatch=slow_dispatch, cleanup=cleanup, max_corrective_attempts=0
+    )
+    envelope = _envelope(LocalTaskClass.SMALL_CODE_FIX, "touch file x")
+    envelope.timeout_seconds = 0.05
+    envelope.forbidden_files = []
+    evidence = await harness.run(envelope, validator=lambda *a: _always_pass(*a))
+    assert evidence.result_class == "TIMEOUT"
+    assert harness.timeout_cleanup_calls == 1
+    assert cleanup_calls == [1]  # in-flight work was cleaned up exactly once
+    assert evidence.escalation.required is True
+
+
+
+async def test_harness_allows_exactly_one_corrective_then_escalates():
+    dispatch_calls = []
+    fail_then_pass = {"already_used": False}
+
+    async def dispatch(_t, _n):
+        dispatch_calls.append(_n)
+        return '{"kind":"CHANGES_PROPOSED","summary":"fix"}'
+
+    async def validator(_t, _result, _attempt):
+        if not fail_then_pass["already_used"]:
+            fail_then_pass["already_used"] = True
+            return ValidationResult(
+                verdict=LocalValidationVerdict.FAIL, reason="first candidate invalid"
+            )
+        return ValidationResult(verdict=LocalValidationVerdict.PASS, reason="corrected ok")
+
+    harness = LocalWorkerHarness(dispatch=dispatch, max_corrective_attempts=1)
+    envelope = _envelope(LocalTaskClass.SMALL_CODE_FIX, "fix bounds helper")
+    envelope.timeout_seconds = 5.0
+    evidence = await harness.run(envelope, validator=validator)
+    # initial attempt 1 + exactly one corrective attempt 2, never > 2 total dispatches.
+    assert dispatch_calls == [1, 2]
+    assert evidence.corrections_used == 1
+    assert evidence.validation_result is LocalValidationVerdict.PASS
+
+
+async def test_harness_stops_with_escalation_when_corrective_still_fails():
+    dispatch_calls = []
+
+    async def dispatch(_t, _n):
+        dispatch_calls.append(_n)
+        return '{"kind":"CHANGES_PROPOSED","summary":"still bad"}'
+
+    harness = LocalWorkerHarness(dispatch=dispatch, max_corrective_attempts=1)
+    envelope = _envelope(LocalTaskClass.SMALL_REFACTOR, "rename a local var")
+    envelope.timeout_seconds = 5.0
+    evidence = await harness.run(envelope, validator=lambda *a: _always_fail(*a))
+    # exactly 2 total attempts (1 initial + 1 corrective), then stop/escalate, no unbounded retry.
+    assert dispatch_calls == [1, 2]
+    assert evidence.result_class == "VALIDATION_FAILED"
+    assert evidence.escalation.required is True
+    assert evidence.escalation.target is EscalationTarget.EXISTING_PROVIDER_POLICY
+
+
+# --- service orchestration: forbidden refused pre-dispatch, success run yields evidence ---
+
+
+async def test_service_refuses_forbidden_class_never_dispatches():
+    from minime.local_worker.service import LocalWorkerService
+
+    calls = {"net": 0}
+
+    async def no_dispatch_generate(**kwargs):
+        calls["net"] += 1
+        raise AssertionError("must never reach the adapter on a refused task")
+
+    service = LocalWorkerService()
+    service.adapter.generate = no_dispatch_generate  # type: ignore[method-assign]
+    envelope = _envelope(
+        LocalTaskClass.SMALL_CODE_FIX, "rotate the API token stored by the credentials helper"
+    )
+    outcome = await service.run(envelope, validator=_always_pass)
+    assert outcome.evidence.result_class == "REFUSED"
+    assert outcome.evidence.task_class == envelope.task_class.value
+    assert outcome.evidence.escalation.required is True
+    assert calls["net"] == 0  # forbidden work was never executed
+
+
+async def test_service_success_run_yields_minimal_structured_evidence():
+    from minime.domain.enums import ProviderResultClass
+    from minime.local_worker.model_identity import OLLAMA_PROVIDER
+    from minime.local_worker.models import PreflightResult, PreflightStatus
+    from minime.local_worker.service import LocalWorkerService
+
+    ready = PreflightResult(
+        provider=OLLAMA_PROVIDER,
+        model=local_qwen_model_identity(),
+        status=PreflightStatus.READY,
+        reachable=True,
+        model_present=True,
+    )
+
+    async def fake_generate(*, system_prompt=None, prompt=None, client=None):
+        return OllamaGenerateResponse(
+            result_class=ProviderResultClass.SUCCESS,
+            text='{"kind":"CHANGES_PROPOSED","summary":"bumped the index check"}',
+        )
+
+    service = LocalWorkerService()
+    service.adapter.generate = fake_generate  # type: ignore[method-assign]
+    envelope = _envelope(LocalTaskClass.SMALL_CODE_FIX, "fix off-by-one in helper")
+    envelope.timeout_seconds = 10.0
+    outcome = await service.run(envelope, validator=lambda *a: _always_pass(*a), preflight=ready)
+    assert isinstance(outcome.evidence, LocalExecutionEvidence)
+    evidence = outcome.evidence
+    assert evidence.provider == "ollama"
+    assert evidence.model == "qwen2.5-coder:7b-instruct-q4_K_M"
+    assert evidence.task_class == envelope.task_class.value
+    assert evidence.attempt == 1
+    assert evidence.result_class == "SUCCESS"
+    assert evidence.validation_result is LocalValidationVerdict.PASS
+    assert evidence.escalation.required is False
+    assert evidence.result is LocalResultKind.CHANGES_PROPOSED
+
+
+
+
+


### PR DESCRIPTION
## Summary
- add bounded, offline-testable Ollama/Qwen local worker bootstrap
- enforce LOW-risk eligibility, forbidden surfaces, deterministic validation, one corrective attempt, and escalation
- add OpenSpec artifacts and focused offline tests

## Verification
- `openspec validate minimal-local-worker-bootstrap --strict` ✅
- `ruff check src/minime/local_worker tests/test_local_worker_bootstrap.py` ✅
- focused tests: 20 passed ✅
- full suite: sandbox blocks existing localhost bind test; 147 passed before first unrelated failure

## Candidate identity
- base: `4161ddfa00432916e5dbb2df46e41ffdd08c1f45`
- head: `25c3d32d165b1906c779d524386b0cb5aff941f8`

Do not merge automatically; independent review and human merge remain required.